### PR TITLE
Bill & Billhook Rework

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -7796,7 +7796,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h1" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.52" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_blade_h1" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.50" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
@@ -7811,7 +7811,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_billhook_blade_h2" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.48" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="5" />
+      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -7821,9 +7821,9 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h3" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.45" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_blade_h3" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.48" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="5" />
+      <Swing damage_type="Cut" damage_factor="5.0" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -33060,20 +33060,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_blade_h0" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.505">
-    <BuildData piece_offset="-7.6" />
-    <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.7" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="CanDismount" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_bill_blade_h1" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.505">
+  <CraftingPiece id="crpg_bill_blade_h0" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.8" />
@@ -33086,10 +33073,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_blade_h2" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.505">
+  <CraftingPiece id="crpg_bill_blade_h1" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="4" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33099,10 +33086,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_blade_h3" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.505">
+  <CraftingPiece id="crpg_bill_blade_h2" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33112,25 +33099,38 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_handle_h0" name="{=}Cheap Bill Handle" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+  <CraftingPiece id="crpg_bill_blade_h3" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5">
+    <BuildData piece_offset="-7.6" />
+    <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Swing damage_type="Cut" damage_factor="4.2" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="CanDismount" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_bill_handle_h0" name="{=}Cheap Bill Handle" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="0.5" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
     <BuildData piece_offset="19.4" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_handle_h1" name="{=}Cheap Bill Handle" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.5" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+  <CraftingPiece id="crpg_bill_handle_h1" name="{=}Cheap Bill Handle" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="0.43" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
     <BuildData piece_offset="19.4" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_handle_h2" name="{=}Cheap Bill Handle" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.5" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+  <CraftingPiece id="crpg_bill_handle_h2" name="{=}Cheap Bill Handle" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="0.43" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
     <BuildData piece_offset="19.4" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_handle_h3" name="{=}Cheap Bill Handle" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.4" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+  <CraftingPiece id="crpg_bill_handle_h3" name="{=}Cheap Bill Handle" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="0.43" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
     <BuildData piece_offset="19.4" />
     <Materials>
       <Material id="Wood" count="1" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -7760,36 +7760,37 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-    <CraftingPiece id="crpg_billhook_handle_h0" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+    <CraftingPiece id="crpg_billhook_handle_h0" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="0.2" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
     <BuildData piece_offset="19.4" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_handle_h1" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+  <CraftingPiece id="crpg_billhook_handle_h1" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="0.2" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
     <BuildData piece_offset="19.4" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_handle_h2" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+  <CraftingPiece id="crpg_billhook_handle_h2" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="0.2" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
     <BuildData piece_offset="19.4" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_handle_h3" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+  <CraftingPiece id="crpg_billhook_handle_h3" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="0.2" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
     <BuildData piece_offset="19.4" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h0" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.52" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_blade_h0" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.2" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
+      <Flag name="CanDismount" />
     </Flags>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -7801,6 +7802,8 @@
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
+      <Flag name="CanDismount" />
+      
     </Flags>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -7812,6 +7815,7 @@
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
+      <Flag name="CanDismount" />
     </Flags>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -7823,26 +7827,27 @@
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
+      <Flag name="CanDismount" />
     </Flags>
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_guard_h0" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  <CraftingPiece id="crpg_billhook_guard_h0" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0.10" is_default="true">
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_guard_h1" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  <CraftingPiece id="crpg_billhook_guard_h1" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0.10" is_default="true">
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_guard_h2" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  <CraftingPiece id="crpg_billhook_guard_h2" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0.10" is_default="true">
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_guard_h3" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  <CraftingPiece id="crpg_billhook_guard_h3" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0.10" is_default="true">
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_pommel_h0" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  <CraftingPiece id="crpg_billhook_pommel_h0" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0.10" is_default="true">
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_pommel_h1" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  <CraftingPiece id="crpg_billhook_pommel_h1" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0.10" is_default="true">
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_pommel_h2" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  <CraftingPiece id="crpg_billhook_pommel_h2" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0.10" is_default="true">
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_pommel_h3" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  <CraftingPiece id="crpg_billhook_pommel_h3" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0.10" is_default="true">
   </CraftingPiece>
   <CraftingPiece id="crpg_iron_pitchfork_blade_h0" name="{=SVBYn9KW}Iron Fork" tier="1" piece_type="Blade" mesh="spear_blade_32" length="32.7" weight="0.7176" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
@@ -33068,6 +33073,7 @@
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
       <Flag name="CanDismount" />
+      <Flag name="CanHook"/>
     </Flags>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -33081,6 +33087,7 @@
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
       <Flag name="CanDismount" />
+      <Flag name="CanHook"/>
     </Flags>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -33094,6 +33101,7 @@
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
       <Flag name="CanDismount" />
+      <Flag name="CanHook"/>
     </Flags>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -33107,6 +33115,7 @@
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
       <Flag name="CanDismount" />
+      <Flag name="CanHook"/>
     </Flags>
     <Materials>
       <Material id="Iron4" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2276,14 +2276,6 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_warrazor_pommel_h3" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_pommel_h0" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_pommel_h1" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_pommel_h2" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_pommel_h3" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
-  </CraftingPiece>
   <CraftingPiece id="crpg_bludgeon_staff_pommel_h0" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
   </CraftingPiece>
   <CraftingPiece id="crpg_bludgeon_staff_pommel_h1" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
@@ -4044,30 +4036,6 @@
       <Material id="Wood" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_handle_h0" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
-    <BuildData piece_offset="19.4" />
-    <Materials>
-      <Material id="Wood" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_handle_h1" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
-    <BuildData piece_offset="19.4" />
-    <Materials>
-      <Material id="Wood" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_handle_h2" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
-    <BuildData piece_offset="19.4" />
-    <Materials>
-      <Material id="Wood" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_handle_h3" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
-    <BuildData piece_offset="19.4" />
-    <Materials>
-      <Material id="Wood" count="1" />
-    </Materials>
-  </CraftingPiece>
   <CraftingPiece id="crpg_jagged_spear_handle_h0" name="{=71588OX7}Bamboo Shaft" tier="2" piece_type="Handle" mesh="spear_handle_3" length="179" weight="1.3" excluded_item_usage_features="long" CraftingCost="100">
     <BuildData piece_offset="17.9" />
     <Materials>
@@ -4663,14 +4631,6 @@
   <CraftingPiece id="crpg_warrazor_guard_h2" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
   </CraftingPiece>
   <CraftingPiece id="crpg_warrazor_guard_h3" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_guard_h0" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_guard_h1" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_guard_h2" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_guard_h3" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
   </CraftingPiece>
   <CraftingPiece id="crpg_pilum_guard_h0" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
   </CraftingPiece>
@@ -7800,6 +7760,30 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
+    <CraftingPiece id="crpg_billhook_handle_h0" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+    <BuildData piece_offset="19.4" />
+    <Materials>
+      <Material id="Wood" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_handle_h1" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+    <BuildData piece_offset="19.4" />
+    <Materials>
+      <Material id="Wood" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_handle_h2" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+    <BuildData piece_offset="19.4" />
+    <Materials>
+      <Material id="Wood" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_handle_h3" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+    <BuildData piece_offset="19.4" />
+    <Materials>
+      <Material id="Wood" count="1" />
+    </Materials>
+  </CraftingPiece>
   <CraftingPiece id="crpg_billhook_blade_h0" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.52" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Cut" damage_factor="4.7" />
@@ -7843,6 +7827,22 @@
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_guard_h0" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_guard_h1" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_guard_h2" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_guard_h3" name="{=koX9okuG}None" tier="1" piece_type="Guard" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_pommel_h0" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_pommel_h1" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_pommel_h2" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_pommel_h3" name="{=koX9okuG}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
   </CraftingPiece>
   <CraftingPiece id="crpg_iron_pitchfork_blade_h0" name="{=SVBYn9KW}Iron Fork" tier="1" piece_type="Blade" mesh="spear_blade_32" length="32.7" weight="0.7176" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -7784,7 +7784,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h0" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.2" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_blade_h0" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.52" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
@@ -7796,9 +7796,9 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h1" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.52" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_blade_h1" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.52" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.9" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -7809,7 +7809,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h2" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.48" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_blade_h2" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.48" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Cut" damage_factor="5" />
     </BladeData>
@@ -7821,7 +7821,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h3" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.45" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_blade_h3" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.45" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Cut" damage_factor="5" />
     </BladeData>

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -13182,26 +13182,26 @@
   </CraftedItem>
   <CraftedItem id="crpg_bill_v1_h0" name="{=Salt}Bill" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_bill_blade_h0" Type="Blade" scale_factor="120" />
-      <Piece id="crpg_bill_handle_h0" Type="Handle" scale_factor="80" />
+      <Piece id="crpg_bill_blade_h0" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_bill_handle_h0" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_bill_v1_h1" name="{=Salt}Bill +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_bill_blade_h1" Type="Blade" scale_factor="120" />
-      <Piece id="crpg_bill_handle_h1" Type="Handle" scale_factor="80" />
+      <Piece id="crpg_bill_blade_h1" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_bill_handle_h1" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_bill_v1_h2" name="{=Salt}Bill +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_bill_blade_h2" Type="Blade" scale_factor="120" />
-      <Piece id="crpg_bill_handle_h2" Type="Handle" scale_factor="80" />
+      <Piece id="crpg_bill_blade_h2" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_bill_handle_h2" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_bill_v1_h3" name="{=Salt}Bill +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_bill_blade_h3" Type="Blade" scale_factor="120" />
-      <Piece id="crpg_bill_handle_h3" Type="Handle" scale_factor="80" />
+      <Piece id="crpg_bill_blade_h3" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_bill_handle_h3" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_short_voulge_v1_h0" name="{=Salt}Short Voulge" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -8574,25 +8574,25 @@
   </CraftedItem>
   <CraftedItem id="crpg_billhook_v4_h1" name="{=kaikaikai}Billhook +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_billhook_blade_h1" Type="Blade" scale_factor="140" />
+      <Piece id="crpg_billhook_blade_h1" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h1" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_billhook_handle_h1" Type="Handle" scale_factor="80" />
+      <Piece id="crpg_billhook_handle_h1" Type="Handle" scale_factor="96" />
       <Piece id="crpg_billhook_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_billhook_v4_h2" name="{=kaikaikai}Billhook +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_billhook_blade_h2" Type="Blade" scale_factor="140" />
+      <Piece id="crpg_billhook_blade_h2" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h2" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_billhook_handle_h2" Type="Handle" scale_factor="80" />
+      <Piece id="crpg_billhook_handle_h2" Type="Handle" scale_factor="96" />
       <Piece id="crpg_billhook_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_billhook_v4_h3" name="{=kaikaikai}Billhook +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_billhook_blade_h3" Type="Blade" scale_factor="140" />
+      <Piece id="crpg_billhook_blade_h3" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h3" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_billhook_handle_h3" Type="Handle" scale_factor="80" />
+      <Piece id="crpg_billhook_handle_h3" Type="Handle" scale_factor="96" />
       <Piece id="crpg_billhook_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -8566,9 +8566,9 @@
   </CraftedItem>
   <CraftedItem id="crpg_billhook_v4_h0" name="{=kaikaikai}Billhook" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_billhook_blade_h0" Type="Blade" scale_factor="140" />
+      <Piece id="crpg_billhook_blade_h0" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h0" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_billhook_handle_h0" Type="Handle" scale_factor="80" />
+      <Piece id="crpg_billhook_handle_h0" Type="Handle" scale_factor="96" />
       <Piece id="crpg_billhook_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -8564,7 +8564,7 @@
       <Piece id="crpg_warrazor_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v4_h0" name="{=kaikaikai}Billhook" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v5_h0" name="{=Yeldur}Billhook" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h0" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h0" Type="Guard" scale_factor="100" />
@@ -8572,7 +8572,7 @@
       <Piece id="crpg_billhook_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v4_h1" name="{=kaikaikai}Billhook +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v5_h1" name="{=Yeldur}Billhook +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h1" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h1" Type="Guard" scale_factor="100" />
@@ -8580,7 +8580,7 @@
       <Piece id="crpg_billhook_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v4_h2" name="{=kaikaikai}Billhook +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v5_h2" name="{=Yeldur}Billhook +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h2" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h2" Type="Guard" scale_factor="100" />
@@ -8588,7 +8588,7 @@
       <Piece id="crpg_billhook_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v4_h3" name="{=kaikaikai}Billhook +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v5_h3" name="{=Yeldur}Billhook +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h3" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h3" Type="Guard" scale_factor="100" />
@@ -13180,25 +13180,25 @@
       <Piece id="crpg_short_bardiche_handle_h3" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bill_v1_h0" name="{=Salt}Bill" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_bill_v2_h0" name="{=Yeldur}Bill" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_bill_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bill_handle_h0" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bill_v1_h1" name="{=Salt}Bill +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_bill_v2_h1" name="{=Yeldur}Bill +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_bill_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bill_handle_h1" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bill_v1_h2" name="{=Salt}Bill +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_bill_v2_h2" name="{=Yeldur}Bill +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_bill_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bill_handle_h2" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bill_v1_h3" name="{=Salt}Bill +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_bill_v2_h3" name="{=Yeldur}Bill +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_bill_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bill_handle_h3" Type="Handle" scale_factor="115" />


### PR DESCRIPTION
Rework Bill & Billhook, reorganise Billhook components in `crafting_pieces.xml`, to ensure they are grouped together.

Currently we don't have (m)**any**(?) 4D dismount weapons, this change serves to add this into the mix by reworking two weapons that are currently seldom used in the hopes of granting them more space on the field in the form of buffing a niche they can fill.

This PR also reorganises the Billhook components within `crafting_pieces.xml`, ensuring they are grouped together. This adjustment does not alter the item's functionality, but rather serves to improve QoL by preventing pieces being scattered randomly throughout the XML.