### PR TITLE
Fix Partisan Refund | Push autocalc to resolve whitespace issues

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -7804,7 +7804,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-    <CraftingPiece id="crpg_billhook_handle_h0" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="0.2" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+  <CraftingPiece id="crpg_billhook_handle_h0" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="0.2" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
     <BuildData piece_offset="19.4" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -7847,7 +7847,6 @@
     <Flags>
       <Flag name="CanHook" />
       <Flag name="CanDismount" />
-      
     </Flags>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -33297,7 +33296,7 @@
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
       <Flag name="CanDismount" />
-      <Flag name="CanHook"/>
+      <Flag name="CanHook" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -33311,7 +33310,7 @@
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
       <Flag name="CanDismount" />
-      <Flag name="CanHook"/>
+      <Flag name="CanHook" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -33325,7 +33324,7 @@
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
       <Flag name="CanDismount" />
-      <Flag name="CanHook"/>
+      <Flag name="CanHook" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -33339,7 +33338,7 @@
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
       <Flag name="CanDismount" />
-      <Flag name="CanHook"/>
+      <Flag name="CanHook" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="2" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -14444,7 +14444,7 @@
       <Piece id="crpg_templarsword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_at_partisan_h0" name="{=AppleTruce}Partisan" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_at_partisan_v2_h0" name="{=AppleTruce}Partisan" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_at_partisan_blade_h0" Type="Blade" scale_factor="102" />
       <Piece id="crpg_at_partisan_handle_h0" Type="Handle" scale_factor="98" />
@@ -14452,7 +14452,7 @@
       <Piece id="crpg_at_partisan_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_at_partisan_h1" name="{=AppleTruce}Partisan +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_at_partisan_v2_h1" name="{=AppleTruce}Partisan +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_at_partisan_blade_h1" Type="Blade" scale_factor="102" />
       <Piece id="crpg_at_partisan_handle_h1" Type="Handle" scale_factor="98" />
@@ -14460,7 +14460,7 @@
       <Piece id="crpg_at_partisan_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_at_partisan_h2" name="{=AppleTruce}Partisan +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_at_partisan_v2_h2" name="{=AppleTruce}Partisan +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_at_partisan_blade_h2" Type="Blade" scale_factor="102" />
       <Piece id="crpg_at_partisan_handle_h2" Type="Handle" scale_factor="98" />
@@ -14468,7 +14468,7 @@
       <Piece id="crpg_at_partisan_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_at_partisan_h3" name="{=AppleTruce}Partisan +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_at_partisan_v2_h3" name="{=AppleTruce}Partisan +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_at_partisan_blade_h3" Type="Blade" scale_factor="102" />
       <Piece id="crpg_at_partisan_handle_h3" Type="Handle" scale_factor="98" />


### PR DESCRIPTION
Partisan refund was pushed by manually changing items.json - This will result in a mismatch between the game and the site.

Resolved by setting weapons.xml to the correct version, am also pushing an autocalc to push whitespace changes for the purpose of cleanliness.
