### PR TITLE
Roman weapons rebalance

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20402,8 +20402,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h0" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="3.1" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -20411,8 +20411,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h1" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="3.2" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -20420,17 +20420,17 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h2" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="3.3" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h3" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="1.5">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h3" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="1.4">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="3.4" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -23915,7 +23915,7 @@
   <CraftingPiece id="crpg_spatha_blade_h1" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="0.65">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23926,8 +23926,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spatha_blade_h2" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="0.65">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23936,7 +23936,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="0.65">
+  <CraftingPiece id="crpg_spatha_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="0.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.9" />
@@ -23962,8 +23962,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h1" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23975,7 +23975,7 @@
   <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h2" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23984,9 +23984,9 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.0">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="0.95">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
       <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
@@ -29570,65 +29570,65 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_gladius_pompeian_blade_h0" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.empire" length="46.5" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="3.4" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
   </CraftingPiece>
   <CraftingPiece id="crpg_gladius_pompeian_blade_h1" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.battania" length="46.5" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="3.5" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
   </CraftingPiece>
   <CraftingPiece id="crpg_gladius_pompeian_blade_h2" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.battania" length="46.5" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.6" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_blade_h3" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.battania" length="46.5" weight="1.5">
+  <CraftingPiece id="crpg_gladius_pompeian_blade_h3" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.battania" length="46.5" weight="1.3">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="3.7" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_pommel_h0" name="{=}Pompeian Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_pompeian_pommel" culture="Culture.battania" length="8.45" weight="0.01">
+  <CraftingPiece id="crpg_gladius_pompeian_pommel_h0" name="{=}Pompeian Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_pompeian_pommel" culture="Culture.battania" length="8.45" weight="0.5">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_pommel_h1" name="{=}Pompeian Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_pompeian_pommel" culture="Culture.battania" length="8.45" weight="0.01">
+  <CraftingPiece id="crpg_gladius_pompeian_pommel_h1" name="{=}Pompeian Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_pompeian_pommel" culture="Culture.battania" length="8.45" weight="0.5">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_pommel_h2" name="{=}Pompeian Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_pompeian_pommel" culture="Culture.battania" length="8.45" weight="0.01">
+  <CraftingPiece id="crpg_gladius_pompeian_pommel_h2" name="{=}Pompeian Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_pompeian_pommel" culture="Culture.battania" length="8.45" weight="0.5">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_pommel_h3" name="{=}Pompeian Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_pompeian_pommel" culture="Culture.battania" length="8.45" weight="0.01">
+  <CraftingPiece id="crpg_gladius_pompeian_pommel_h3" name="{=}Pompeian Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_pompeian_pommel" culture="Culture.battania" length="8.45" weight="0.5">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_guard_h0" name="{=}Pompeian Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_pompeian_guard" culture="Culture.battania" length="5.79" weight="0.01">
+  <CraftingPiece id="crpg_gladius_pompeian_guard_h0" name="{=}Pompeian Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_pompeian_guard" culture="Culture.battania" length="5.79" weight="0.5">
     <BuildData next_piece_offset="5" />
     <StatContributions armor_bonus="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_guard_h1" name="{=}Pompeian Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_pompeian_guard" culture="Culture.battania" length="5.79" weight="0.01">
+  <CraftingPiece id="crpg_gladius_pompeian_guard_h1" name="{=}Pompeian Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_pompeian_guard" culture="Culture.battania" length="5.79" weight="0.5">
     <BuildData next_piece_offset="5" />
     <StatContributions armor_bonus="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_guard_h2" name="{=}Pompeian Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_pompeian_guard" culture="Culture.battania" length="5.79" weight="0.01">
+  <CraftingPiece id="crpg_gladius_pompeian_guard_h2" name="{=}Pompeian Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_pompeian_guard" culture="Culture.battania" length="5.79" weight="0.5">
     <BuildData next_piece_offset="5" />
     <StatContributions armor_bonus="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_guard_h3" name="{=}Pompeian Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_pompeian_guard" culture="Culture.battania" length="5.79" weight="0.01">
+  <CraftingPiece id="crpg_gladius_pompeian_guard_h3" name="{=}Pompeian Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_pompeian_guard" culture="Culture.battania" length="5.79" weight="0.5">
     <BuildData next_piece_offset="5" />
     <StatContributions armor_bonus="0" />
   </CraftingPiece>
@@ -29644,156 +29644,156 @@
   <CraftingPiece id="crpg_gladius_pompeian_handle_h3" name="{=}Pompeian Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_pompeian_handle" culture="Culture.khuzait" length="12.5" weight="0.01">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_blade_h0" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.empire" length="59.8" weight="1.55">
+  <CraftingPiece id="crpg_gladius_mainz_blade_h0" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.empire" length="59.8" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="3.2" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_blade_h1" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.55">
+  <CraftingPiece id="crpg_gladius_mainz_blade_h1" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="3.3" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_blade_h2" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.55">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="3.3" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
-    </BladeData>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_blade_h3" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.55">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="3.5" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
-    </BladeData>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_pommel_h0" name="{=}Mainz Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_mainz_pommel" culture="Culture.battania" length="6.34" weight="0.01">
-    <BuildData next_piece_offset="0" />
-    <Materials>
-      <Material id="Iron4" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_pommel_h1" name="{=}Mainz Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_mainz_pommel" culture="Culture.battania" length="6.34" weight="0.01">
-    <BuildData next_piece_offset="0" />
-    <Materials>
-      <Material id="Iron4" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_pommel_h2" name="{=}Mainz Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_mainz_pommel" culture="Culture.battania" length="6.34" weight="0.01">
-    <BuildData next_piece_offset="0" />
-    <Materials>
-      <Material id="Iron4" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_pommel_h3" name="{=}Mainz Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_mainz_pommel" culture="Culture.battania" length="6.34" weight="0.01">
-    <BuildData next_piece_offset="0" />
-    <Materials>
-      <Material id="Iron4" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_guard_h0" name="{=}Mainz Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_mainz_guard" culture="Culture.battania" length="6.2" weight="0.01">
-    <BuildData next_piece_offset="7" />
-    <StatContributions armor_bonus="0" />
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_guard_h1" name="{=}Mainz Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_mainz_guard" culture="Culture.battania" length="6.2" weight="0.01">
-    <BuildData next_piece_offset="7" />
-    <StatContributions armor_bonus="0" />
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_guard_h2" name="{=}Mainz Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_mainz_guard" culture="Culture.battania" length="6.2" weight="0.01">
-    <BuildData next_piece_offset="7" />
-    <StatContributions armor_bonus="0" />
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_guard_h3" name="{=}Mainz Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_mainz_guard" culture="Culture.battania" length="6.2" weight="0.01">
-    <BuildData next_piece_offset="7" />
-    <StatContributions armor_bonus="0" />
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_handle_h0" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.01">
-    <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_handle_h1" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.01">
-    <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_handle_h2" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.01">
-    <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_handle_h3" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.01">
-    <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
-  </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_blade_h0" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.5">
+  <CraftingPiece id="crpg_gladius_mainz_blade_h2" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_blade_h1" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.5">
+  <CraftingPiece id="crpg_gladius_mainz_blade_h3" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="3.1" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_blade_h2" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.5">
+  <CraftingPiece id="crpg_gladius_mainz_pommel_h0" name="{=}Mainz Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_mainz_pommel" culture="Culture.battania" length="6.34" weight="0.5">
+    <BuildData next_piece_offset="0" />
+    <Materials>
+      <Material id="Iron4" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_pommel_h1" name="{=}Mainz Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_mainz_pommel" culture="Culture.battania" length="6.34" weight="0.5">
+    <BuildData next_piece_offset="0" />
+    <Materials>
+      <Material id="Iron4" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_pommel_h2" name="{=}Mainz Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_mainz_pommel" culture="Culture.battania" length="6.34" weight="0.5">
+    <BuildData next_piece_offset="0" />
+    <Materials>
+      <Material id="Iron4" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_pommel_h3" name="{=}Mainz Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_mainz_pommel" culture="Culture.battania" length="6.34" weight="0.5">
+    <BuildData next_piece_offset="0" />
+    <Materials>
+      <Material id="Iron4" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_guard_h0" name="{=}Mainz Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_mainz_guard" culture="Culture.battania" length="6.2" weight="0.5">
+    <BuildData next_piece_offset="7" />
+    <StatContributions armor_bonus="0" />
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_guard_h1" name="{=}Mainz Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_mainz_guard" culture="Culture.battania" length="6.2" weight="0.5">
+    <BuildData next_piece_offset="7" />
+    <StatContributions armor_bonus="0" />
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_guard_h2" name="{=}Mainz Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_mainz_guard" culture="Culture.battania" length="6.2" weight="0.5">
+    <BuildData next_piece_offset="7" />
+    <StatContributions armor_bonus="0" />
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_guard_h3" name="{=}Mainz Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_mainz_guard" culture="Culture.battania" length="6.2" weight="0.5">
+    <BuildData next_piece_offset="7" />
+    <StatContributions armor_bonus="0" />
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_handle_h0" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.5">
+    <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_handle_h1" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.5">
+    <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_handle_h2" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.5">
+    <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_mainz_handle_h3" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.5">
+    <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_republican_blade_h0" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="3.2" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_blade_h3" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.5">
+  <CraftingPiece id="crpg_gladius_republican_blade_h1" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.2">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
+      <Thrust damage_type="Pierce" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
+    </BladeData>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_republican_blade_h2" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.4" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_pommel_h0" name="{=}Republican Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_republican_pommel" culture="Culture.battania" length="7.04" weight="0.02">
+  <CraftingPiece id="crpg_gladius_republican_blade_h3" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.1">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
+      <Thrust damage_type="Pierce" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
+    </BladeData>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_gladius_republican_pommel_h0" name="{=}Republican Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_republican_pommel" culture="Culture.battania" length="7.04" weight="0.5">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_pommel_h1" name="{=}Republican Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_republican_pommel" culture="Culture.battania" length="7.04" weight="0.02">
+  <CraftingPiece id="crpg_gladius_republican_pommel_h1" name="{=}Republican Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_republican_pommel" culture="Culture.battania" length="7.04" weight="0.5">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_pommel_h2" name="{=}Republican Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_republican_pommel" culture="Culture.battania" length="7.04" weight="0.02">
+  <CraftingPiece id="crpg_gladius_republican_pommel_h2" name="{=}Republican Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_republican_pommel" culture="Culture.battania" length="7.04" weight="0.5">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_pommel_h3" name="{=}Republican Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_republican_pommel" culture="Culture.battania" length="7.04" weight="0.02">
+  <CraftingPiece id="crpg_gladius_republican_pommel_h3" name="{=}Republican Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_republican_pommel" culture="Culture.battania" length="7.04" weight="0.5">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_guard_h0" name="{=}Republican Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_republican_guard" culture="Culture.battania" length="5.74" weight="0.03">
+  <CraftingPiece id="crpg_gladius_republican_guard_h0" name="{=}Republican Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_republican_guard" culture="Culture.battania" length="5.74" weight="0.5">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_guard_h1" name="{=}Republican Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_republican_guard" culture="Culture.battania" length="5.74" weight="0.03">
+  <CraftingPiece id="crpg_gladius_republican_guard_h1" name="{=}Republican Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_republican_guard" culture="Culture.battania" length="5.74" weight="0.5">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_guard_h2" name="{=}Republican Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_republican_guard" culture="Culture.battania" length="5.74" weight="0.03">
+  <CraftingPiece id="crpg_gladius_republican_guard_h2" name="{=}Republican Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_republican_guard" culture="Culture.battania" length="5.74" weight="0.5">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_guard_h3" name="{=}Republican Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_republican_guard" culture="Culture.battania" length="5.74" weight="0.03">
+  <CraftingPiece id="crpg_gladius_republican_guard_h3" name="{=}Republican Gladius Guard" tier="5" piece_type="Guard" mesh="gladius_republican_guard" culture="Culture.battania" length="5.74" weight="0.5">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_handle_h0" name="{=}Republican Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_republican_handle" culture="Culture.khuzait" length="15.7" weight="0.02">
+  <CraftingPiece id="crpg_gladius_republican_handle_h0" name="{=}Republican Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_republican_handle" culture="Culture.khuzait" length="15.7" weight="0.4">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_handle_h1" name="{=}Republican Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_republican_handle" culture="Culture.khuzait" length="15.7" weight="0.02">
+  <CraftingPiece id="crpg_gladius_republican_handle_h1" name="{=}Republican Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_republican_handle" culture="Culture.khuzait" length="15.7" weight="0.4">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_handle_h2" name="{=}Republican Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_republican_handle" culture="Culture.khuzait" length="15.7" weight="0.02">
+  <CraftingPiece id="crpg_gladius_republican_handle_h2" name="{=}Republican Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_republican_handle" culture="Culture.khuzait" length="15.7" weight="0.4">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_handle_h3" name="{=}Republican Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_republican_handle" culture="Culture.khuzait" length="15.7" weight="0.02">
+  <CraftingPiece id="crpg_gladius_republican_handle_h3" name="{=}Republican Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_republican_handle" culture="Culture.khuzait" length="15.7" weight="0.4">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
   <CraftingPiece id="crpg_red_nodachi_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.08" excluded_item_usage_features="thrust">

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -29574,22 +29574,22 @@
       <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_blade_h1" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.battania" length="46.5" weight="1.5">
+  <CraftingPiece id="crpg_gladius_pompeian_blade_h1" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.battania" length="46.5" weight="1.4">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.6" />
       <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_blade_h2" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.battania" length="46.5" weight="1.5">
+  <CraftingPiece id="crpg_gladius_pompeian_blade_h2" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.battania" length="46.5" weight="1.4">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.6" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_pompeian_blade_h3" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.battania" length="46.5" weight="1.3">
+  <CraftingPiece id="crpg_gladius_pompeian_blade_h3" name="{=}Pompeian Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_pompeian_blade" culture="Culture.battania" length="46.5" weight="1.35">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.6" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
   </CraftingPiece>
   <CraftingPiece id="crpg_gladius_pompeian_pommel_h0" name="{=}Pompeian Gladius Pommel" tier="4" piece_type="Pommel" mesh="gladius_pompeian_pommel" culture="Culture.battania" length="8.45" weight="0.5">
@@ -29644,25 +29644,25 @@
   <CraftingPiece id="crpg_gladius_pompeian_handle_h3" name="{=}Pompeian Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_pompeian_handle" culture="Culture.khuzait" length="12.5" weight="0.01">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_blade_h0" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.empire" length="59.8" weight="1.2">
+  <CraftingPiece id="crpg_gladius_mainz_blade_h0" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.empire" length="59.8" weight="1.24">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
       <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_blade_h1" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.2">
+  <CraftingPiece id="crpg_gladius_mainz_blade_h1" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.24">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
       <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_blade_h2" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.2">
+  <CraftingPiece id="crpg_gladius_mainz_blade_h2" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.24">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_blade_h3" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.1">
+  <CraftingPiece id="crpg_gladius_mainz_blade_h3" name="{=}Mainz Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_mainz_blade" culture="Culture.battania" length="59.8" weight="1.15">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="3.9" />
@@ -29708,37 +29708,37 @@
     <BuildData next_piece_offset="7" />
     <StatContributions armor_bonus="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_handle_h0" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.5">
+  <CraftingPiece id="crpg_gladius_mainz_handle_h0" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.3">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_handle_h1" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.5">
+  <CraftingPiece id="crpg_gladius_mainz_handle_h1" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.3">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_handle_h2" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.5">
+  <CraftingPiece id="crpg_gladius_mainz_handle_h2" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.3">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_mainz_handle_h3" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.5">
+  <CraftingPiece id="crpg_gladius_mainz_handle_h3" name="{=}Mainz Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_mainz_handle" culture="Culture.khuzait" length="11.3" weight="0.3">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_blade_h0" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.2">
+  <CraftingPiece id="crpg_gladius_republican_blade_h0" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_blade_h1" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.2">
+  <CraftingPiece id="crpg_gladius_republican_blade_h1" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_blade_h2" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.2">
+  <CraftingPiece id="crpg_gladius_republican_blade_h2" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.4" />
       <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gladius_republican_blade_h3" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.1">
+  <CraftingPiece id="crpg_gladius_republican_blade_h3" name="{=}Republican Gladius Blade" tier="4" piece_type="Blade" mesh="gladius_republican_blade" culture="Culture.battania" length="65" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="3.4" />
       <Swing damage_type="Cut" damage_factor="3.6" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -12018,7 +12018,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_mainz_v2_h0" name="{=Diggles}Mainz Gladius" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_mainz_blade_h0" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_gladius_mainz_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_gladius_mainz_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_mainz_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_mainz_pommel_h0" Type="Pommel" scale_factor="100" />
@@ -12026,7 +12026,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_mainz_v2_h1" name="{=Diggles}Mainz Gladius +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_mainz_blade_h1" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_gladius_mainz_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_gladius_mainz_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_mainz_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_mainz_pommel_h1" Type="Pommel" scale_factor="100" />
@@ -12034,7 +12034,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_mainz_v2_h2" name="{=Diggles}Mainz Gladius +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_mainz_blade_h2" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_gladius_mainz_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_gladius_mainz_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_mainz_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_mainz_pommel_h2" Type="Pommel" scale_factor="100" />
@@ -12042,7 +12042,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_mainz_v2_h3" name="{=Diggles}Mainz Gladius +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_mainz_blade_h3" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_gladius_mainz_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_gladius_mainz_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_mainz_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_mainz_pommel_h3" Type="Pommel" scale_factor="100" />
@@ -12050,7 +12050,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_pompeian_v2_h0" name="{=Diggles}Pompeian Gladius" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_pompeian_blade_h0" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_gladius_pompeian_blade_h0" Type="Blade" scale_factor="120" />
       <Piece id="crpg_gladius_pompeian_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_pompeian_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_pompeian_pommel_h0" Type="Pommel" scale_factor="100" />
@@ -12058,7 +12058,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_pompeian_v2_h1" name="{=Diggles}Pompeian Gladius +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_pompeian_blade_h1" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_gladius_pompeian_blade_h1" Type="Blade" scale_factor="120" />
       <Piece id="crpg_gladius_pompeian_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_pompeian_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_pompeian_pommel_h1" Type="Pommel" scale_factor="100" />
@@ -12066,7 +12066,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_pompeian_v2_h2" name="{=Diggles}Pompeian Gladius +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_pompeian_blade_h2" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_gladius_pompeian_blade_h2" Type="Blade" scale_factor="120" />
       <Piece id="crpg_gladius_pompeian_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_pompeian_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_pompeian_pommel_h2" Type="Pommel" scale_factor="100" />
@@ -12074,7 +12074,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_pompeian_v2_h3" name="{=Diggles}Pompeian Gladius +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_pompeian_blade_h3" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_gladius_pompeian_blade_h3" Type="Blade" scale_factor="120" />
       <Piece id="crpg_gladius_pompeian_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_pompeian_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_pompeian_pommel_h3" Type="Pommel" scale_factor="100" />
@@ -12082,7 +12082,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_republican_v2_h0" name="{=Diggles}Republican Gladius" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_republican_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_gladius_republican_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_gladius_republican_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_republican_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_republican_pommel_h0" Type="Pommel" scale_factor="100" />
@@ -12090,7 +12090,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_republican_v2_h1" name="{=Diggles}Republican Gladius +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_republican_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_gladius_republican_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_gladius_republican_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_republican_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_republican_pommel_h1" Type="Pommel" scale_factor="100" />
@@ -12098,7 +12098,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_republican_v2_h2" name="{=Diggles}Republican Gladius +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_republican_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_gladius_republican_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_gladius_republican_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_republican_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_republican_pommel_h2" Type="Pommel" scale_factor="100" />
@@ -12106,7 +12106,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_gladius_republican_v2_h3" name="{=Diggles}Republican Gladius +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_gladius_republican_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_gladius_republican_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_gladius_republican_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_gladius_republican_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_gladius_republican_pommel_h3" Type="Pommel" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -6096,7 +6096,7 @@
       <Piece id="crpg_decorated_kaskara_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v3_h0" name="{=Diggles}Prefect's Spatha" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v4_h0" name="{=Diggles}Prefect's Spatha" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h0" Type="Blade" scale_factor="84" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_guard_h0" Type="Guard" scale_factor="90" />
@@ -6104,7 +6104,7 @@
       <Piece id="crpg_spatha_blade_with_ring_pommel_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v3_h1" name="{=Diggles}Prefect's Spatha +1" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v4_h1" name="{=Diggles}Prefect's Spatha +1" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h1" Type="Blade" scale_factor="84" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_guard_h1" Type="Guard" scale_factor="90" />
@@ -6112,7 +6112,7 @@
       <Piece id="crpg_spatha_blade_with_ring_pommel_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v3_h2" name="{=Diggles}Prefect's Spatha +2" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v4_h2" name="{=Diggles}Prefect's Spatha +2" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h2" Type="Blade" scale_factor="84" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_guard_h2" Type="Guard" scale_factor="90" />
@@ -6120,7 +6120,7 @@
       <Piece id="crpg_spatha_blade_with_ring_pommel_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v3_h3" name="{=Diggles}Prefect's Spatha +3" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v4_h3" name="{=Diggles}Prefect's Spatha +3" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h3" Type="Blade" scale_factor="84" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_guard_h3" Type="Guard" scale_factor="90" />
@@ -7440,7 +7440,7 @@
       <Piece id="crpg_slightly_ridged_flyssa_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_v3_h0" name="{=Diggles}Cavalry Spatha" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_v4_h0" name="{=Diggles}Cavalry Spatha" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_spatha_guard_h0" Type="Guard" scale_factor="100" />
@@ -7448,7 +7448,7 @@
       <Piece id="crpg_spatha_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_v3_h1" name="{=Diggles}Cavalry Spatha +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_v4_h1" name="{=Diggles}Cavalry Spatha +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_spatha_guard_h1" Type="Guard" scale_factor="100" />
@@ -7456,7 +7456,7 @@
       <Piece id="crpg_spatha_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_v3_h2" name="{=Diggles}Cavalry Spatha +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_v4_h2" name="{=Diggles}Cavalry Spatha +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_spatha_guard_h2" Type="Guard" scale_factor="100" />
@@ -7464,7 +7464,7 @@
       <Piece id="crpg_spatha_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_v3_h3" name="{=Diggles}Cavalry Spatha +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_v4_h3" name="{=Diggles}Cavalry Spatha +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_spatha_guard_h3" Type="Guard" scale_factor="100" />
@@ -7472,7 +7472,7 @@
       <Piece id="crpg_spatha_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_with_narrow_fuller_v3_h0" name="{=Diggles}Imperial Spatha" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_with_narrow_fuller_v4_h0" name="{=Diggles}Imperial Spatha" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_with_narrow_fuller_blade_h0" Type="Blade" scale_factor="87" />
       <Piece id="crpg_spatha_with_narrow_fuller_guard_h0" Type="Guard" scale_factor="100" />
@@ -7480,7 +7480,7 @@
       <Piece id="crpg_spatha_with_narrow_fuller_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_with_narrow_fuller_v3_h1" name="{=Diggles}Imperial Spatha +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_with_narrow_fuller_v4_h1" name="{=Diggles}Imperial Spatha +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_with_narrow_fuller_blade_h1" Type="Blade" scale_factor="87" />
       <Piece id="crpg_spatha_with_narrow_fuller_guard_h1" Type="Guard" scale_factor="100" />
@@ -7488,7 +7488,7 @@
       <Piece id="crpg_spatha_with_narrow_fuller_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_with_narrow_fuller_v3_h2" name="{=Diggles}Imperial Spatha +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_with_narrow_fuller_v4_h2" name="{=Diggles}Imperial Spatha +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_with_narrow_fuller_blade_h2" Type="Blade" scale_factor="87" />
       <Piece id="crpg_spatha_with_narrow_fuller_guard_h2" Type="Guard" scale_factor="100" />
@@ -7496,7 +7496,7 @@
       <Piece id="crpg_spatha_with_narrow_fuller_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_with_narrow_fuller_v3_h3" name="{=Diggles}Imperial Spatha +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_with_narrow_fuller_v4_h3" name="{=Diggles}Imperial Spatha +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_spatha_with_narrow_fuller_blade_h3" Type="Blade" scale_factor="87" />
       <Piece id="crpg_spatha_with_narrow_fuller_guard_h3" Type="Guard" scale_factor="100" />
@@ -12016,7 +12016,7 @@
       <Piece id="crpg_short_western_mace_handle_h3" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_mainz_v1_h0" name="{=Diggles}Mainz Gladius" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_mainz_v2_h0" name="{=Diggles}Mainz Gladius" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_mainz_blade_h0" Type="Blade" scale_factor="105" />
       <Piece id="crpg_gladius_mainz_guard_h0" Type="Guard" scale_factor="100" />
@@ -12024,7 +12024,7 @@
       <Piece id="crpg_gladius_mainz_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_mainz_v1_h1" name="{=Diggles}Mainz Gladius +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_mainz_v2_h1" name="{=Diggles}Mainz Gladius +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_mainz_blade_h1" Type="Blade" scale_factor="105" />
       <Piece id="crpg_gladius_mainz_guard_h1" Type="Guard" scale_factor="100" />
@@ -12032,7 +12032,7 @@
       <Piece id="crpg_gladius_mainz_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_mainz_v1_h2" name="{=Diggles}Mainz Gladius +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_mainz_v2_h2" name="{=Diggles}Mainz Gladius +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_mainz_blade_h2" Type="Blade" scale_factor="105" />
       <Piece id="crpg_gladius_mainz_guard_h2" Type="Guard" scale_factor="100" />
@@ -12040,7 +12040,7 @@
       <Piece id="crpg_gladius_mainz_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_mainz_v1_h3" name="{=Diggles}Mainz Gladius +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_mainz_v2_h3" name="{=Diggles}Mainz Gladius +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_mainz_blade_h3" Type="Blade" scale_factor="105" />
       <Piece id="crpg_gladius_mainz_guard_h3" Type="Guard" scale_factor="100" />
@@ -12048,7 +12048,7 @@
       <Piece id="crpg_gladius_mainz_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_pompeian_v1_h0" name="{=Diggles}Pompeian Gladius" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_pompeian_v2_h0" name="{=Diggles}Pompeian Gladius" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_pompeian_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_gladius_pompeian_guard_h0" Type="Guard" scale_factor="100" />
@@ -12056,7 +12056,7 @@
       <Piece id="crpg_gladius_pompeian_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_pompeian_v1_h1" name="{=Diggles}Pompeian Gladius +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_pompeian_v2_h1" name="{=Diggles}Pompeian Gladius +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_pompeian_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_gladius_pompeian_guard_h1" Type="Guard" scale_factor="100" />
@@ -12064,7 +12064,7 @@
       <Piece id="crpg_gladius_pompeian_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_pompeian_v1_h2" name="{=Diggles}Pompeian Gladius +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_pompeian_v2_h2" name="{=Diggles}Pompeian Gladius +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_pompeian_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_gladius_pompeian_guard_h2" Type="Guard" scale_factor="100" />
@@ -12072,7 +12072,7 @@
       <Piece id="crpg_gladius_pompeian_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_pompeian_v1_h3" name="{=Diggles}Pompeian Gladius +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_pompeian_v2_h3" name="{=Diggles}Pompeian Gladius +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_pompeian_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_gladius_pompeian_guard_h3" Type="Guard" scale_factor="100" />
@@ -12080,7 +12080,7 @@
       <Piece id="crpg_gladius_pompeian_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_republican_v1_h0" name="{=Diggles}Republican Gladius" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_republican_v2_h0" name="{=Diggles}Republican Gladius" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_republican_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_gladius_republican_guard_h0" Type="Guard" scale_factor="100" />
@@ -12088,7 +12088,7 @@
       <Piece id="crpg_gladius_republican_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_republican_v1_h1" name="{=Diggles}Republican Gladius +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_republican_v2_h1" name="{=Diggles}Republican Gladius +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_republican_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_gladius_republican_guard_h1" Type="Guard" scale_factor="100" />
@@ -12096,7 +12096,7 @@
       <Piece id="crpg_gladius_republican_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_republican_v1_h2" name="{=Diggles}Republican Gladius +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_republican_v2_h2" name="{=Diggles}Republican Gladius +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_republican_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_gladius_republican_guard_h2" Type="Guard" scale_factor="100" />
@@ -12104,7 +12104,7 @@
       <Piece id="crpg_gladius_republican_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gladius_republican_v1_h3" name="{=Diggles}Republican Gladius +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_gladius_republican_v2_h3" name="{=Diggles}Republican Gladius +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_gladius_republican_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_gladius_republican_guard_h3" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
Updated stats and loom paths for various Roman-style weapons, for more "useable" 1h cut options with ACIV coming

Mainz Gladius
Republican Gladius
Pompeiian Gladius
Cavalry Spatha
Imperial Spatha
Prefects Spatha

Refunds issued