### PR TITLE
Fixes and tweaks from v116

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -3286,19 +3286,19 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cataphract_lance_handle_h1" name="{=8yb60cDi}Mahogany Long Spear Shaft" tier="4" piece_type="Handle" mesh="spear_handle_24" length="260" weight="1.3">
+  <CraftingPiece id="crpg_cataphract_lance_handle_h1" name="{=8yb60cDi}Mahogany Long Spear Shaft" tier="4" piece_type="Handle" mesh="spear_handle_24" length="260" weight="1.45">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cataphract_lance_handle_h2" name="{=8yb60cDi}Mahogany Long Spear Shaft" tier="4" piece_type="Handle" mesh="spear_handle_24" length="260" weight="1.0">
+  <CraftingPiece id="crpg_cataphract_lance_handle_h2" name="{=8yb60cDi}Mahogany Long Spear Shaft" tier="4" piece_type="Handle" mesh="spear_handle_24" length="260" weight="1.45">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cataphract_lance_handle_h3" name="{=8yb60cDi}Mahogany Long Spear Shaft" tier="4" piece_type="Handle" mesh="spear_handle_24" length="260" weight="1.0">
+  <CraftingPiece id="crpg_cataphract_lance_handle_h3" name="{=8yb60cDi}Mahogany Long Spear Shaft" tier="4" piece_type="Handle" mesh="spear_handle_24" length="260" weight="1.45">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -7728,7 +7728,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cataphract_lance_blade_h0" name="{=S75vUGzK}Fine Steel Hewing Spear Head" tier="5" piece_type="Blade" mesh="spear_blade_6" length="84.4" weight="0.5" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_cataphract_lance_blade_h0" name="{=S75vUGzK}Fine Steel Hewing Spear Head" tier="5" piece_type="Blade" mesh="spear_blade_6" length="84.4" weight="0.55" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
@@ -7744,7 +7744,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cataphract_lance_blade_h2" name="{=S75vUGzK}Fine Steel Hewing Spear Head" tier="5" piece_type="Blade" mesh="spear_blade_6" length="84.4" weight="0.5" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_cataphract_lance_blade_h2" name="{=S75vUGzK}Fine Steel Hewing Spear Head" tier="5" piece_type="Blade" mesh="spear_blade_6" length="84.4" weight="0.45" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
@@ -7752,7 +7752,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cataphract_lance_blade_h3" name="{=S75vUGzK}Fine Steel Hewing Spear Head" tier="5" piece_type="Blade" mesh="spear_blade_6" length="84.4" weight="0.5" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_cataphract_lance_blade_h3" name="{=S75vUGzK}Fine Steel Hewing Spear Head" tier="5" piece_type="Blade" mesh="spear_blade_6" length="84.4" weight="0.45" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
     </BladeData>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -33272,7 +33272,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_blade_h0" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5">
+  <CraftingPiece id="crpg_bill_blade_h0" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.8" />
@@ -33286,7 +33286,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_blade_h1" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5">
+  <CraftingPiece id="crpg_bill_blade_h1" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.8" />
@@ -33300,7 +33300,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_blade_h2" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5">
+  <CraftingPiece id="crpg_bill_blade_h2" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="4.0" />
@@ -33314,7 +33314,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bill_blade_h3" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5">
+  <CraftingPiece id="crpg_bill_blade_h3" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="4.2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -25320,37 +25320,21 @@
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
-    <Flags>
-      <Flag name="CanDismount" />
-      <Flag name="CanHook" />
-    </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_guard_h1" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
-    <Flags>
-      <Flag name="CanDismount" />
-      <Flag name="CanHook" />
-    </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_guard_h2" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
-    <Flags>
-      <Flag name="CanDismount" />
-      <Flag name="CanHook" />
-    </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_guard_h3" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
-    <Flags>
-      <Flag name="CanDismount" />
-      <Flag name="CanHook" />
-    </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_pommel_h0" name="{=}Mace Shaped Pommel" tier="4" piece_type="Pommel" mesh="spear_pommel_11" culture="Culture.empire" length="10" weight="0.07">
     <Materials>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -7302,25 +7302,25 @@
   </Item>
   <Item id="crpg_ar_horse_armor_s_v1_h0" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
-      <Armor body_armor="9" mane_cover_type="none" family_type="8" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
+      <Armor body_armor="9" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_ar_horse_armor_s_v1_h1" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red +1" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
-      <Armor body_armor="12" mane_cover_type="none" family_type="8" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
+      <Armor body_armor="12" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_ar_horse_armor_s_v1_h2" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red +2" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
-      <Armor body_armor="15" mane_cover_type="none" family_type="8" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
+      <Armor body_armor="15" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_ar_horse_armor_s_v1_h3" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red +3" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
-      <Armor body_armor="18" mane_cover_type="none" family_type="8" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
+      <Armor body_armor="18" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -8084,25 +8084,25 @@
       <Piece id="crpg_noble_cavalry_lance_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_lance_v2_h0" name="{=Telford}Cataphract Lance" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_cataphract_lance_v3_h0" name="{=Telford}Cataphract Lance" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_cataphract_lance_blade_h0" Type="Blade" scale_factor="124" />
       <Piece id="crpg_cataphract_lance_handle_h0" Type="Handle" scale_factor="118" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_lance_v2_h1" name="{=Telford}Cataphract Lance +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_cataphract_lance_v3_h1" name="{=Telford}Cataphract Lance +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_cataphract_lance_blade_h1" Type="Blade" scale_factor="124" />
       <Piece id="crpg_cataphract_lance_handle_h1" Type="Handle" scale_factor="118" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_lance_v2_h2" name="{=Telford}Cataphract Lance +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_cataphract_lance_v3_h2" name="{=Telford}Cataphract Lance +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_cataphract_lance_blade_h2" Type="Blade" scale_factor="124" />
       <Piece id="crpg_cataphract_lance_handle_h2" Type="Handle" scale_factor="118" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_lance_v2_h3" name="{=Telford}Cataphract Lance +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_cataphract_lance_v3_h3" name="{=Telford}Cataphract Lance +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_cataphract_lance_blade_h3" Type="Blade" scale_factor="124" />
       <Piece id="crpg_cataphract_lance_handle_h3" Type="Handle" scale_factor="118" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2024,30 +2024,6 @@
       <Piece id="crpg_raider_throwing_axe_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h0" name="{=X31qND4N}Tribesman Throwing Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe_throwing">
-    <Pieces>
-      <Piece id="crpg_tribesman_throwing_axe_melee_blade_h0" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_tribesman_throwing_axe_melee_handle_h0" Type="Handle" scale_factor="115" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h1" name="{=X31qND4N}Tribesman Throwing Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe_throwing">
-    <Pieces>
-      <Piece id="crpg_tribesman_throwing_axe_melee_blade_h1" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_tribesman_throwing_axe_melee_handle_h1" Type="Handle" scale_factor="115" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h2" name="{=X31qND4N}Tribesman Throwing Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe_throwing">
-    <Pieces>
-      <Piece id="crpg_tribesman_throwing_axe_melee_blade_h2" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_tribesman_throwing_axe_melee_handle_h2" Type="Handle" scale_factor="115" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h3" name="{=X31qND4N}Tribesman Throwing Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe_throwing">
-    <Pieces>
-      <Piece id="crpg_tribesman_throwing_axe_melee_blade_h3" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_tribesman_throwing_axe_melee_handle_h3" Type="Handle" scale_factor="115" />
-    </Pieces>
-  </CraftedItem>
   <CraftedItem id="crpg_tribesman_throwing_axe_v3_h0" name="{=X31qND4N}Tribesman Throwing Axe" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
     <Pieces>
       <Piece id="crpg_tribesman_throwing_axe_blade_h0" Type="Blade" scale_factor="100" />
@@ -14292,7 +14268,7 @@
       <Piece id="crpg_ibelinsword_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_ibelinsword_h1" name="{=STAFF}Ibelin Sword" crafting_template="crpg_OneHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_disabled_ibelinsword_h1" name="{=STAFF}Ibelin Sword +1" crafting_template="crpg_OneHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_ibelinsword_blade_h1" Type="Blade" scale_factor="95" />
       <Piece id="crpg_ibelinsword_guard_h1" Type="Guard" scale_factor="100" />
@@ -14300,7 +14276,7 @@
       <Piece id="crpg_ibelinsword_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_ibelinsword_h2" name="{=STAFF}Ibelin Sword" crafting_template="crpg_OneHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_disabled_ibelinsword_h2" name="{=STAFF}Ibelin Sword +2" crafting_template="crpg_OneHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_ibelinsword_blade_h2" Type="Blade" scale_factor="95" />
       <Piece id="crpg_ibelinsword_guard_h2" Type="Guard" scale_factor="100" />
@@ -14308,7 +14284,7 @@
       <Piece id="crpg_ibelinsword_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_ibelinsword_h3" name="{=STAFF}Ibelin Sword" crafting_template="crpg_OneHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_disabled_ibelinsword_h3" name="{=STAFF}Ibelin Sword +3" crafting_template="crpg_OneHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_ibelinsword_blade_h3" Type="Blade" scale_factor="95" />
       <Piece id="crpg_ibelinsword_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -122,30 +122,6 @@
   </CraftedItem>
   <CraftedItem id="crpg_spiked_polehammer_v6_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
-      <Piece id="crpg_spiked_polehammer_knockdown_blade_h0" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_spiked_polehammer_knockdown_handle_h0" Type="Handle" scale_factor="100" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
-    <Pieces>
-      <Piece id="crpg_spiked_polehammer_knockdown_blade_h1" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_spiked_polehammer_knockdown_handle_h1" Type="Handle" scale_factor="100" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
-    <Pieces>
-      <Piece id="crpg_spiked_polehammer_knockdown_blade_h2" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_spiked_polehammer_knockdown_handle_h2" Type="Handle" scale_factor="100" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
-    <Pieces>
-      <Piece id="crpg_spiked_polehammer_knockdown_blade_h3" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_spiked_polehammer_knockdown_handle_h3" Type="Handle" scale_factor="100" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
-    <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
@@ -166,6 +142,30 @@
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h3" Type="Handle" scale_factor="100" />
+    </Pieces>
+  </CraftedItem>
+  <CraftedItem id="crpg_spiked_polehammer_v6_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
+    <Pieces>
+      <Piece id="crpg_spiked_polehammer_knockdown_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spiked_polehammer_knockdown_handle_h0" Type="Handle" scale_factor="100" />
+    </Pieces>
+  </CraftedItem>
+  <CraftedItem id="crpg_spiked_polehammer_v6_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
+    <Pieces>
+      <Piece id="crpg_spiked_polehammer_knockdown_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spiked_polehammer_knockdown_handle_h1" Type="Handle" scale_factor="100" />
+    </Pieces>
+  </CraftedItem>
+  <CraftedItem id="crpg_spiked_polehammer_v6_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
+    <Pieces>
+      <Piece id="crpg_spiked_polehammer_knockdown_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spiked_polehammer_knockdown_handle_h2" Type="Handle" scale_factor="100" />
+    </Pieces>
+  </CraftedItem>
+  <CraftedItem id="crpg_spiked_polehammer_v6_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
+    <Pieces>
+      <Piece id="crpg_spiked_polehammer_knockdown_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spiked_polehammer_knockdown_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_warhammer_v2_h0" name="{=}Warhammer" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2024,25 +2024,25 @@
       <Piece id="crpg_raider_throwing_axe_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h0" name="{=X31qND4N}Tribesman Throwing Axe" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+  <CraftedItem id="crpg_tribesman_throwing_axe_v4_h0" name="{=X31qND4N}Tribesman Throwing Axe" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
     <Pieces>
       <Piece id="crpg_tribesman_throwing_axe_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tribesman_throwing_axe_handle_h0" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h1" name="{=X31qND4N}Tribesman Throwing Axe +1" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+  <CraftedItem id="crpg_tribesman_throwing_axe_v4_h1" name="{=X31qND4N}Tribesman Throwing Axe +1" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
     <Pieces>
       <Piece id="crpg_tribesman_throwing_axe_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tribesman_throwing_axe_handle_h1" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h2" name="{=X31qND4N}Tribesman Throwing Axe +2" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+  <CraftedItem id="crpg_tribesman_throwing_axe_v4_h2" name="{=X31qND4N}Tribesman Throwing Axe +2" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
     <Pieces>
       <Piece id="crpg_tribesman_throwing_axe_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tribesman_throwing_axe_handle_h2" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h3" name="{=X31qND4N}Tribesman Throwing Axe +3" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+  <CraftedItem id="crpg_tribesman_throwing_axe_v4_h3" name="{=X31qND4N}Tribesman Throwing Axe +3" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
     <Pieces>
       <Piece id="crpg_tribesman_throwing_axe_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tribesman_throwing_axe_handle_h3" Type="Handle" scale_factor="115" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2024,25 +2024,49 @@
       <Piece id="crpg_raider_throwing_axe_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v4_h0" name="{=X31qND4N}Tribesman Throwing Axe" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h0" name="{=X31qND4N}Tribesman Throwing Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+    <Pieces>
+      <Piece id="crpg_tribesman_throwing_axe_melee_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_tribesman_throwing_axe_melee_handle_h0" Type="Handle" scale_factor="115" />
+    </Pieces>
+  </CraftedItem>
+  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h1" name="{=X31qND4N}Tribesman Throwing Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+    <Pieces>
+      <Piece id="crpg_tribesman_throwing_axe_melee_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_tribesman_throwing_axe_melee_handle_h1" Type="Handle" scale_factor="115" />
+    </Pieces>
+  </CraftedItem>
+  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h2" name="{=X31qND4N}Tribesman Throwing Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+    <Pieces>
+      <Piece id="crpg_tribesman_throwing_axe_melee_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_tribesman_throwing_axe_melee_handle_h2" Type="Handle" scale_factor="115" />
+    </Pieces>
+  </CraftedItem>
+  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h3" name="{=X31qND4N}Tribesman Throwing Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+    <Pieces>
+      <Piece id="crpg_tribesman_throwing_axe_melee_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_tribesman_throwing_axe_melee_handle_h3" Type="Handle" scale_factor="115" />
+    </Pieces>
+  </CraftedItem>
+  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h0" name="{=X31qND4N}Tribesman Throwing Axe" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
     <Pieces>
       <Piece id="crpg_tribesman_throwing_axe_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tribesman_throwing_axe_handle_h0" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v4_h1" name="{=X31qND4N}Tribesman Throwing Axe +1" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h1" name="{=X31qND4N}Tribesman Throwing Axe +1" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
     <Pieces>
       <Piece id="crpg_tribesman_throwing_axe_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tribesman_throwing_axe_handle_h1" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v4_h2" name="{=X31qND4N}Tribesman Throwing Axe +2" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h2" name="{=X31qND4N}Tribesman Throwing Axe +2" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
     <Pieces>
       <Piece id="crpg_tribesman_throwing_axe_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tribesman_throwing_axe_handle_h2" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tribesman_throwing_axe_v4_h3" name="{=X31qND4N}Tribesman Throwing Axe +3" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
+  <CraftedItem id="crpg_tribesman_throwing_axe_v3_h3" name="{=X31qND4N}Tribesman Throwing Axe +3" crafting_template="crpg_ThrowingAxe" culture="Culture.aserai" modifier_group="axe_throwing">
     <Pieces>
       <Piece id="crpg_tribesman_throwing_axe_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tribesman_throwing_axe_handle_h3" Type="Handle" scale_factor="115" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -14348,7 +14348,7 @@
       <Piece id="crpg_dragonslayer_pommel_h3" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <Item id="crpg_disabled_cla_musket_ammo_h0" name="{=Meow}Black-powder Ammo" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" flying_mesh="lyon_bullet" mesh="torch_flame_base" holster_mesh="stone_holster" holster_mesh_with_weapon="stone_holster" weight="0.3" appearance="1.0" Type="Bullets" item_holsters="throwing_stone:throwing_stone_2" is_merchandise="true">
+  <Item id="crpg_cla_musket_ammo_h0" name="{=Meow}Black-powder Ammo" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" flying_mesh="lyon_bullet" mesh="torch_flame_base" holster_mesh="stone_holster" holster_mesh_with_weapon="stone_holster" weight="0.3" appearance="1.0" Type="Bullets" item_holsters="throwing_stone:throwing_stone_2" is_merchandise="true">
     <ItemComponent>
       <Weapon weapon_class="Cartridge" stack_amount="9" thrust_speed="0" speed_rating="0" missile_speed="10" thrust_damage="10" thrust_damage_type="Pierce" weapon_length="37" item_usage="" rotation="180, 0, 0" physics_material="missile" sticking_position="0,-0.37,0" sticking_rotation="90,0,0" trail_particle_name="cla_smoke_musket" passby_sound_code="event:/mission/combat/missile/passby" center_of_mass="0,0,0">
         <WeaponFlags Consumable="true" AmmoBreaksOnBounceBack="true" UseHandAsThrowBase="true" LeavesTrail="true" FirearmAmmo="true" />
@@ -14356,7 +14356,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_disabled_cla_musket_ammo_h1" name="{=Meow}Black-powder Ammo +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" flying_mesh="lyon_bullet" mesh="torch_flame_base" holster_mesh="stone_holster" holster_mesh_with_weapon="stone_holster" weight="0.3" appearance="1.0" Type="Bullets" item_holsters="throwing_stone:throwing_stone_2" is_merchandise="true">
+  <Item id="crpg_cla_musket_ammo_h1" name="{=Meow}Black-powder Ammo +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" flying_mesh="lyon_bullet" mesh="torch_flame_base" holster_mesh="stone_holster" holster_mesh_with_weapon="stone_holster" weight="0.3" appearance="1.0" Type="Bullets" item_holsters="throwing_stone:throwing_stone_2" is_merchandise="true">
     <ItemComponent>
       <Weapon weapon_class="Cartridge" stack_amount="10" thrust_speed="0" speed_rating="0" missile_speed="10" thrust_damage="11" thrust_damage_type="Pierce" weapon_length="37" item_usage="" rotation="180, 0, 0" physics_material="missile" sticking_position="0,-0.37,0" sticking_rotation="90,0,0" trail_particle_name="cla_smoke_musket" passby_sound_code="event:/mission/combat/missile/passby" center_of_mass="0,0,0">
         <WeaponFlags Consumable="true" AmmoBreaksOnBounceBack="true" UseHandAsThrowBase="true" LeavesTrail="true" FirearmAmmo="true" />
@@ -14364,7 +14364,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_disabled_cla_musket_ammo_h2" name="{=Meow}Black-powder Ammo +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" flying_mesh="lyon_bullet" mesh="torch_flame_base" holster_mesh="stone_holster" holster_mesh_with_weapon="stone_holster" weight="0.3" appearance="1.0" Type="Bullets" item_holsters="throwing_stone:throwing_stone_2" is_merchandise="true">
+  <Item id="crpg_cla_musket_ammo_h2" name="{=Meow}Black-powder Ammo +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" flying_mesh="lyon_bullet" mesh="torch_flame_base" holster_mesh="stone_holster" holster_mesh_with_weapon="stone_holster" weight="0.3" appearance="1.0" Type="Bullets" item_holsters="throwing_stone:throwing_stone_2" is_merchandise="true">
     <ItemComponent>
       <Weapon weapon_class="Cartridge" stack_amount="11" thrust_speed="0" speed_rating="0" missile_speed="10" thrust_damage="12" thrust_damage_type="Pierce" weapon_length="37" item_usage="" rotation="180, 0, 0" physics_material="missile" sticking_position="0,-0.37,0" sticking_rotation="90,0,0" trail_particle_name="cla_smoke_musket" passby_sound_code="event:/mission/combat/missile/passby" center_of_mass="0,0,0">
         <WeaponFlags Consumable="true" AmmoBreaksOnBounceBack="true" UseHandAsThrowBase="true" LeavesTrail="true" FirearmAmmo="true" />
@@ -14372,7 +14372,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_disabled_cla_musket_ammo_h3" name="{=Meow}Black-powder Ammo +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" flying_mesh="lyon_bullet" mesh="torch_flame_base" holster_mesh="stone_holster" holster_mesh_with_weapon="stone_holster" weight="0.3" appearance="1.0" Type="Bullets" item_holsters="throwing_stone:throwing_stone_2" is_merchandise="true">
+  <Item id="crpg_cla_musket_ammo_h3" name="{=Meow}Black-powder Ammo +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" flying_mesh="lyon_bullet" mesh="torch_flame_base" holster_mesh="stone_holster" holster_mesh_with_weapon="stone_holster" weight="0.3" appearance="1.0" Type="Bullets" item_holsters="throwing_stone:throwing_stone_2" is_merchandise="true">
     <ItemComponent>
       <Weapon weapon_class="Cartridge" stack_amount="12" thrust_speed="0" speed_rating="0" missile_speed="10" thrust_damage="13" thrust_damage_type="Pierce" weapon_length="37" item_usage="" rotation="180, 0, 0" physics_material="missile" sticking_position="0,-0.37,0" sticking_rotation="90,0,0" trail_particle_name="cla_smoke_musket" passby_sound_code="event:/mission/combat/missile/passby" center_of_mass="0,0,0">
         <WeaponFlags Consumable="true" AmmoBreaksOnBounceBack="true" UseHandAsThrowBase="true" LeavesTrail="true" FirearmAmmo="true" />
@@ -14380,7 +14380,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_disabled_handgonne_h0" name="{=Meow}Handgonne" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_handgonne_h0" name="{=Meow}Handgonne" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="112" accuracy="95" thrust_damage="53" thrust_speed="80" speed_rating="55" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
@@ -14388,7 +14388,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_disabled_handgonne_h1" name="{=Meow}Handgonne +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_handgonne_h1" name="{=Meow}Handgonne +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="112" accuracy="96" thrust_damage="54" thrust_speed="81" speed_rating="57" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
@@ -14396,7 +14396,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_disabled_handgonne_h2" name="{=Meow}Handgonne +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_handgonne_h2" name="{=Meow}Handgonne +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="113" accuracy="97" thrust_damage="55" thrust_speed="82" speed_rating="59" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
@@ -14404,7 +14404,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_disabled_handgonne_h3" name="{=Meow}Handgonne +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_handgonne_h3" name="{=Meow}Handgonne +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="114" accuracy="98" thrust_damage="56" thrust_speed="83" speed_rating="60" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />

--- a/weapon_descriptions.xml
+++ b/weapon_descriptions.xml
@@ -6474,14 +6474,6 @@
       <WeaponFlag value="BonusAgainstShield" />
     </WeaponFlags>
     <AvailablePieces>
-      <AvailablePiece id="crpg_tribesman_throwing_axe_blade_h0" />
-      <AvailablePiece id="crpg_tribesman_throwing_axe_blade_h1" />
-      <AvailablePiece id="crpg_tribesman_throwing_axe_blade_h2" />
-      <AvailablePiece id="crpg_tribesman_throwing_axe_blade_h3" />
-      <AvailablePiece id="crpg_tribesman_throwing_axe_handle_h0" />
-      <AvailablePiece id="crpg_tribesman_throwing_axe_handle_h1" />
-      <AvailablePiece id="crpg_tribesman_throwing_axe_handle_h2" />
-      <AvailablePiece id="crpg_tribesman_throwing_axe_handle_h3" />
       <AvailablePiece id="crpg_runic_axe_blade_h0" />
       <AvailablePiece id="crpg_runic_axe_blade_h1" />
       <AvailablePiece id="crpg_runic_axe_blade_h2" />

--- a/weapon_descriptions.xml
+++ b/weapon_descriptions.xml
@@ -6474,6 +6474,14 @@
       <WeaponFlag value="BonusAgainstShield" />
     </WeaponFlags>
     <AvailablePieces>
+      <AvailablePiece id="crpg_tribesman_throwing_axe_blade_h0" />
+      <AvailablePiece id="crpg_tribesman_throwing_axe_blade_h1" />
+      <AvailablePiece id="crpg_tribesman_throwing_axe_blade_h2" />
+      <AvailablePiece id="crpg_tribesman_throwing_axe_blade_h3" />
+      <AvailablePiece id="crpg_tribesman_throwing_axe_handle_h0" />
+      <AvailablePiece id="crpg_tribesman_throwing_axe_handle_h1" />
+      <AvailablePiece id="crpg_tribesman_throwing_axe_handle_h2" />
+      <AvailablePiece id="crpg_tribesman_throwing_axe_handle_h3" />
       <AvailablePiece id="crpg_runic_axe_blade_h0" />
       <AvailablePiece id="crpg_runic_axe_blade_h1" />
       <AvailablePiece id="crpg_runic_axe_blade_h2" />


### PR DESCRIPTION
- Spiked Polehammer main mode corrected to non-knockdown version
- Corrected Western Heavy Harness family type (needs re-enabling after patch)
- Corrected Ibelin Sword heirloom naming
- Removed Hoplite Spear ability to dismount
- Removed the no damage stab animation from "Bill"
- Enabled Handgonne + Black powder ammo (triggers refund)
- Slightly tiered down the Cataphract Lance so upkeep isn't too high