### PR TITLE
Rebalance Hoplite Spear

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -25320,21 +25320,29 @@
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
+    <Flags>
+    </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_guard_h1" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0.33">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
+    <Flags>
+    </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_guard_h2" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0.33">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
+    <Flags>
+    </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_guard_h3" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0.29">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
+    <Flags>
+    </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_pommel_h0" name="{=}Mace Shaped Pommel" tier="4" piece_type="Pommel" mesh="spear_pommel_11" culture="Culture.empire" length="10" weight="0.35">
     <Materials>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -25260,47 +25260,31 @@
       <Material id="Wood" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_handle_h0" name="{=}Hoplite Ash Shaft" tier="2" piece_type="Handle" mesh="spear_handle_5" length="229" weight="0.95" CraftingCost="110">
+  <CraftingPiece id="crpg_hoplite_spear_handle_h0" name="{=}Hoplite Ash Shaft" tier="2" piece_type="Handle" mesh="spear_handle_5" length="229" weight="0.35" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_handle_h1" name="{=}Hoplite Ash Shaft" tier="2" piece_type="Handle" mesh="spear_handle_5" length="229" weight="0.85" CraftingCost="110">
+  <CraftingPiece id="crpg_hoplite_spear_handle_h1" name="{=}Hoplite Ash Shaft" tier="2" piece_type="Handle" mesh="spear_handle_5" length="229" weight="0.32" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_handle_h2" name="{=}Hoplite Ash Shaft" tier="2" piece_type="Handle" mesh="spear_handle_5" length="229" weight="0.85" CraftingCost="110">
+  <CraftingPiece id="crpg_hoplite_spear_handle_h2" name="{=}Hoplite Ash Shaft" tier="2" piece_type="Handle" mesh="spear_handle_5" length="229" weight="0.32" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_handle_h3" name="{=}Hoplite Ash Shaft" tier="2" piece_type="Handle" mesh="spear_handle_5" length="229" weight="0.65" CraftingCost="110">
+  <CraftingPiece id="crpg_hoplite_spear_handle_h3" name="{=}Hoplite Ash Shaft" tier="2" piece_type="Handle" mesh="spear_handle_5" length="229" weight="0.30" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_blade_h0" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1" excluded_item_usage_features="swing">
-    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.6" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_blade_h1" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1" excluded_item_usage_features="swing">
-    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.6" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_blade_h2" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_hoplite_spear_blade_h0" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.35" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
@@ -25308,7 +25292,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_blade_h3" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_hoplite_spear_blade_h1" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.32" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
@@ -25316,42 +25300,58 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_guard_h0" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0">
+  <CraftingPiece id="crpg_hoplite_spear_blade_h2" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.32" excluded_item_usage_features="swing">
+    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_hoplite_spear_blade_h3" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.30" excluded_item_usage_features="swing">
+    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_hoplite_spear_guard_h0" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0.35">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_guard_h1" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0">
+  <CraftingPiece id="crpg_hoplite_spear_guard_h1" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0.33">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_guard_h2" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0">
+  <CraftingPiece id="crpg_hoplite_spear_guard_h2" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0.33">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_guard_h3" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0">
+  <CraftingPiece id="crpg_hoplite_spear_guard_h3" name="{=}Blunt Wings" tier="4" piece_type="Guard" mesh="spear_guard_3" culture="Culture.empire" length="12.5" weight="0.29">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_pommel_h0" name="{=}Mace Shaped Pommel" tier="4" piece_type="Pommel" mesh="spear_pommel_11" culture="Culture.empire" length="10" weight="0.07">
+  <CraftingPiece id="crpg_hoplite_spear_pommel_h0" name="{=}Mace Shaped Pommel" tier="4" piece_type="Pommel" mesh="spear_pommel_11" culture="Culture.empire" length="10" weight="0.35">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_pommel_h1" name="{=}Mace Shaped Pommel" tier="4" piece_type="Pommel" mesh="spear_pommel_11" culture="Culture.empire" length="10" weight="0.07">
+  <CraftingPiece id="crpg_hoplite_spear_pommel_h1" name="{=}Mace Shaped Pommel" tier="4" piece_type="Pommel" mesh="spear_pommel_11" culture="Culture.empire" length="10" weight="0.33">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_pommel_h2" name="{=}Mace Shaped Pommel" tier="4" piece_type="Pommel" mesh="spear_pommel_11" culture="Culture.empire" length="10" weight="0.07">
+  <CraftingPiece id="crpg_hoplite_spear_pommel_h2" name="{=}Mace Shaped Pommel" tier="4" piece_type="Pommel" mesh="spear_pommel_11" culture="Culture.empire" length="10" weight="0.33">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hoplite_spear_pommel_h3" name="{=}Mace Shaped Pommel" tier="4" piece_type="Pommel" mesh="spear_pommel_11" culture="Culture.empire" length="10" weight="0.07">
+  <CraftingPiece id="crpg_hoplite_spear_pommel_h3" name="{=}Mace Shaped Pommel" tier="4" piece_type="Pommel" mesh="spear_pommel_11" culture="Culture.empire" length="10" weight="0.29">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -25286,7 +25286,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_blade_h0" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.35" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -25294,7 +25294,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_blade_h1" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.32" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -25302,7 +25302,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_blade_h2" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.32" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -25310,7 +25310,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_hoplite_spear_blade_h3" name="{=}Hoplite Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.30" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -760,35 +760,35 @@
       <Piece id="crpg_iklwa_handle_h3" Type="Handle" scale_factor="30" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_hoplite_spear_v4_h0" name="{=}Hoplite Spear" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_hoplite_spear_v5_h0" name="{=}Hoplite Spear" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_hoplite_spear_blade_h0" Type="Blade" scale_factor="90" />
       <Piece id="crpg_hoplite_spear_guard_h0" Type="Guard" scale_factor="90" />
-      <Piece id="crpg_hoplite_spear_handle_h0" Type="Handle" scale_factor="75" />
+      <Piece id="crpg_hoplite_spear_handle_h0" Type="Handle" scale_factor="81" />
       <Piece id="crpg_hoplite_spear_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_hoplite_spear_v4_h1" name="{=}Hoplite Spear +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_hoplite_spear_v5_h1" name="{=}Hoplite Spear +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_hoplite_spear_blade_h1" Type="Blade" scale_factor="90" />
       <Piece id="crpg_hoplite_spear_guard_h1" Type="Guard" scale_factor="90" />
-      <Piece id="crpg_hoplite_spear_handle_h1" Type="Handle" scale_factor="75" />
+      <Piece id="crpg_hoplite_spear_handle_h1" Type="Handle" scale_factor="81" />
       <Piece id="crpg_hoplite_spear_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_hoplite_spear_v4_h2" name="{=}Hoplite Spear +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_hoplite_spear_v5_h2" name="{=}Hoplite Spear +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_hoplite_spear_blade_h2" Type="Blade" scale_factor="90" />
       <Piece id="crpg_hoplite_spear_guard_h2" Type="Guard" scale_factor="90" />
-      <Piece id="crpg_hoplite_spear_handle_h2" Type="Handle" scale_factor="75" />
+      <Piece id="crpg_hoplite_spear_handle_h2" Type="Handle" scale_factor="81" />
       <Piece id="crpg_hoplite_spear_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_hoplite_spear_v4_h3" name="{=}Hoplite Spear +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_hoplite_spear_v5_h3" name="{=}Hoplite Spear +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_hoplite_spear_blade_h3" Type="Blade" scale_factor="90" />
       <Piece id="crpg_hoplite_spear_guard_h3" Type="Guard" scale_factor="90" />
-      <Piece id="crpg_hoplite_spear_handle_h3" Type="Handle" scale_factor="75" />
+      <Piece id="crpg_hoplite_spear_handle_h3" Type="Handle" scale_factor="81" />
       <Piece id="crpg_hoplite_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>


### PR DESCRIPTION
Rebalance Hoplite Spear for fairer balancing

Hoplite Spear for a while now has been a consistent outlier in how strong it is, as a result this change is to address this issue.

From review, I believe the Spear is a victim of rushed and/or lazy crafting resulting in most of the components weight being empty and all the weight being dumped into a single component (something we now know to cause issues in weapons) 

This change re-balances the weapon and elongates it slightly to take away some of its stat strength as a result of its short current length as well as remove its ability to dismount.