### PR TITLE
Cavalry rework items

### DIFF
--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -1,1008 +1,1008 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
-  <Item id="camel_saddle_b_v2_h0" name="{=Meow}Camel Saddle with Light Load" is_merchandise="false" mesh="camel_saddle_b" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="camel_saddle_b_v3_h0" name="{=Meow}Camel Saddle with Light Load" is_merchandise="false" mesh="camel_saddle_b" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="6" mane_cover_type="none" family_type="2" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="camel_saddle_b_v2_h1" name="{=Meow}Camel Saddle with Light Load +1" is_merchandise="false" mesh="camel_saddle_b" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="camel_saddle_b_v3_h1" name="{=Meow}Camel Saddle with Light Load +1" is_merchandise="false" mesh="camel_saddle_b" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="2" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="camel_saddle_b_v2_h2" name="{=Meow}Camel Saddle with Light Load +2" is_merchandise="false" mesh="camel_saddle_b" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="camel_saddle_b_v3_h2" name="{=Meow}Camel Saddle with Light Load +2" is_merchandise="false" mesh="camel_saddle_b" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="2" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="camel_saddle_b_v2_h3" name="{=Meow}Camel Saddle with Light Load +3" is_merchandise="false" mesh="camel_saddle_b" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="camel_saddle_b_v3_h3" name="{=Meow}Camel Saddle with Light Load +3" is_merchandise="false" mesh="camel_saddle_b" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="2" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_camel_saddle_v2_h0" name="{=q1z4FQub}Camel Saddle" mesh="camel_saddle1" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="crpg_camel_saddle_v3_h0" name="{=q1z4FQub}Camel Saddle" mesh="camel_saddle1" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="6" mane_cover_type="none" family_type="2" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_camel_saddle_v2_h1" name="{=q1z4FQub}Camel Saddle +1" mesh="camel_saddle1" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="crpg_camel_saddle_v3_h1" name="{=q1z4FQub}Camel Saddle +1" mesh="camel_saddle1" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="2" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_camel_saddle_v2_h2" name="{=q1z4FQub}Camel Saddle +2" mesh="camel_saddle1" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="crpg_camel_saddle_v3_h2" name="{=q1z4FQub}Camel Saddle +2" mesh="camel_saddle1" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="2" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_camel_saddle_v2_h3" name="{=q1z4FQub}Camel Saddle +3" mesh="camel_saddle1" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="crpg_camel_saddle_v3_h3" name="{=q1z4FQub}Camel Saddle +3" mesh="camel_saddle1" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="2" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_c_v2_h0" name="{=Meow}Mule Harness with Bags" mesh="mule_load_c" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_c_v3_h0" name="{=Meow}Mule Harness with Bags" mesh="mule_load_c" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="6" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_c_v2_h1" name="{=Meow}Mule Harness with Bags +1" mesh="mule_load_c" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_c_v3_h1" name="{=Meow}Mule Harness with Bags +1" mesh="mule_load_c" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_c_v2_h2" name="{=Meow}Mule Harness with Bags +2" mesh="mule_load_c" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_c_v3_h2" name="{=Meow}Mule Harness with Bags +2" mesh="mule_load_c" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_c_v2_h3" name="{=Meow}Mule Harness with Bags +3" mesh="mule_load_c" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_c_v3_h3" name="{=Meow}Mule Harness with Bags +3" mesh="mule_load_c" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_b_v2_h0" name="{=Meow}Mule Harness with Baskets" mesh="mule_load_b" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_b_v3_h0" name="{=Meow}Mule Harness with Baskets" mesh="mule_load_b" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="6" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_b_v2_h1" name="{=Meow}Mule Harness with Baskets +1" mesh="mule_load_b" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_b_v3_h1" name="{=Meow}Mule Harness with Baskets +1" mesh="mule_load_b" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_b_v2_h2" name="{=Meow}Mule Harness with Baskets +2" mesh="mule_load_b" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_b_v3_h2" name="{=Meow}Mule Harness with Baskets +2" mesh="mule_load_b" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_b_v2_h3" name="{=Meow}Mule Harness with Baskets +3" mesh="mule_load_b" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_b_v3_h3" name="{=Meow}Mule Harness with Baskets +3" mesh="mule_load_b" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_a_v2_h0" name="{=Meow}Mule Harness with Pack" mesh="mule_load_a" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_a_v3_h0" name="{=Meow}Mule Harness with Pack" mesh="mule_load_a" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="6" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_a_v2_h1" name="{=Meow}Mule Harness with Pack +1" mesh="mule_load_a" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_a_v3_h1" name="{=Meow}Mule Harness with Pack +1" mesh="mule_load_a" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_a_v2_h2" name="{=Meow}Mule Harness with Pack +2" mesh="mule_load_a" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_a_v3_h2" name="{=Meow}Mule Harness with Pack +2" mesh="mule_load_a" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="mule_load_a_v2_h3" name="{=Meow}Mule Harness with Pack +3" mesh="mule_load_a" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="mule_load_a_v3_h3" name="{=Meow}Mule Harness with Pack +3" mesh="mule_load_a" is_merchandise="false" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="all" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_scaled_v2_h0" name="{=amqJbdDV}Scale Barding" mesh="battania_horse_harness_scaled" culture="Culture.battania" weight="36" appearance="0.65" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_scaled_v3_h0" name="{=amqJbdDV}Scale Barding" mesh="battania_horse_harness_scaled" culture="Culture.battania" weight="36" appearance="0.65" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_scaled_v2_h1" name="{=amqJbdDV}Scale Barding +1" mesh="battania_horse_harness_scaled" culture="Culture.battania" weight="36" appearance="0.65" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_scaled_v3_h1" name="{=amqJbdDV}Scale Barding +1" mesh="battania_horse_harness_scaled" culture="Culture.battania" weight="36" appearance="0.65" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_scaled_v2_h2" name="{=amqJbdDV}Scale Barding +2" mesh="battania_horse_harness_scaled" culture="Culture.battania" weight="36" appearance="0.65" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_scaled_v3_h2" name="{=amqJbdDV}Scale Barding +2" mesh="battania_horse_harness_scaled" culture="Culture.battania" weight="36" appearance="0.65" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_scaled_v2_h3" name="{=amqJbdDV}Scale Barding +3" mesh="battania_horse_harness_scaled" culture="Culture.battania" weight="36" appearance="0.65" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_scaled_v3_h3" name="{=amqJbdDV}Scale Barding +3" mesh="battania_horse_harness_scaled" culture="Culture.battania" weight="36" appearance="0.65" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_halfscaled_v2_h0" name="{=W8r7A7qH}Half Scaled Barding" mesh="battania_horse_harness_halfscaled" culture="Culture.battania" weight="30" appearance="1" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_halfscaled_v3_h0" name="{=W8r7A7qH}Half Scaled Barding" mesh="battania_horse_harness_halfscaled" culture="Culture.battania" weight="30" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_halfscaled_v2_h1" name="{=W8r7A7qH}Half Scaled Barding +1" mesh="battania_horse_harness_halfscaled" culture="Culture.battania" weight="30" appearance="1" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_halfscaled_v3_h1" name="{=W8r7A7qH}Half Scaled Barding +1" mesh="battania_horse_harness_halfscaled" culture="Culture.battania" weight="30" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_halfscaled_v2_h2" name="{=W8r7A7qH}Half Scaled Barding +2" mesh="battania_horse_harness_halfscaled" culture="Culture.battania" weight="30" appearance="1" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_halfscaled_v3_h2" name="{=W8r7A7qH}Half Scaled Barding +2" mesh="battania_horse_harness_halfscaled" culture="Culture.battania" weight="30" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_halfscaled_v2_h3" name="{=W8r7A7qH}Half Scaled Barding +3" mesh="battania_horse_harness_halfscaled" culture="Culture.battania" weight="30" appearance="1" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_halfscaled_v3_h3" name="{=W8r7A7qH}Half Scaled Barding +3" mesh="battania_horse_harness_halfscaled" culture="Culture.battania" weight="30" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_v2_h0" name="{=33aaUcaX}Battania Horse Harness" mesh="battania_horse_harness" culture="Culture.battania" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_v3_h0" name="{=33aaUcaX}Battania Horse Harness" mesh="battania_horse_harness" culture="Culture.battania" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="1" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_v2_h1" name="{=33aaUcaX}Battania Horse Harness +1" mesh="battania_horse_harness" culture="Culture.battania" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_v3_h1" name="{=33aaUcaX}Battania Horse Harness +1" mesh="battania_horse_harness" culture="Culture.battania" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_v2_h2" name="{=33aaUcaX}Battania Horse Harness +2" mesh="battania_horse_harness" culture="Culture.battania" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_v3_h2" name="{=33aaUcaX}Battania Horse Harness +2" mesh="battania_horse_harness" culture="Culture.battania" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_battania_horse_harness_v2_h3" name="{=33aaUcaX}Battania Horse Harness +3" mesh="battania_horse_harness" culture="Culture.battania" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_battania_horse_harness_v3_h3" name="{=33aaUcaX}Battania Horse Harness +3" mesh="battania_horse_harness" culture="Culture.battania" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_ring_barding_v2_h0" name="{=MI65uuKB}Ring Mail Barding" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="24" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_northern_ring_barding_v3_h0" name="{=MI65uuKB}Ring Mail Barding" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="24" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_ring_barding_v2_h1" name="{=MI65uuKB}Ring Mail Barding +1" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="24" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_northern_ring_barding_v3_h1" name="{=MI65uuKB}Ring Mail Barding +1" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="24" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="27" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_ring_barding_v2_h2" name="{=MI65uuKB}Ring Mail Barding +2" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="24" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_northern_ring_barding_v3_h2" name="{=MI65uuKB}Ring Mail Barding +2" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="24" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_ring_barding_v2_h3" name="{=MI65uuKB}Ring Mail Barding +3" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="24" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_northern_ring_barding_v3_h3" name="{=MI65uuKB}Ring Mail Barding +3" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="24" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_noble_harness_v2_h0" name="{=lZZOQsxc}Rough Cavalry Saddle" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="8" appearance="1" Type="HorseHarness">
+  <Item id="crpg_northern_noble_harness_v3_h0" name="{=lZZOQsxc}Rough Cavalry Saddle" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="8" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="8" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_sturgia_b_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_noble_harness_v2_h1" name="{=lZZOQsxc}Rough Cavalry Saddle +1" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="8" appearance="1" Type="HorseHarness">
+  <Item id="crpg_northern_noble_harness_v3_h1" name="{=lZZOQsxc}Rough Cavalry Saddle +1" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="8" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="11" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_sturgia_b_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_noble_harness_v2_h2" name="{=lZZOQsxc}Rough Cavalry Saddle +2" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="8" appearance="1" Type="HorseHarness">
+  <Item id="crpg_northern_noble_harness_v3_h2" name="{=lZZOQsxc}Rough Cavalry Saddle +2" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="8" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_sturgia_b_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_noble_harness_v2_h3" name="{=lZZOQsxc}Rough Cavalry Saddle +3" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="8" appearance="1" Type="HorseHarness">
+  <Item id="crpg_northern_noble_harness_v3_h3" name="{=lZZOQsxc}Rough Cavalry Saddle +3" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="8" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_sturgia_b_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_light_harness_v2_h0" name="{=uRqm1nJ7}Light Saddle" mesh="horse_harness_roman_b_new" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
+  <Item id="crpg_northern_light_harness_v3_h0" name="{=uRqm1nJ7}Light Saddle" mesh="horse_harness_roman_b_new" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="10" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_light_harness_v2_h1" name="{=uRqm1nJ7}Light Saddle +1" mesh="horse_harness_roman_b_new" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
+  <Item id="crpg_northern_light_harness_v3_h1" name="{=uRqm1nJ7}Light Saddle +1" mesh="horse_harness_roman_b_new" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="13" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_light_harness_v2_h2" name="{=uRqm1nJ7}Light Saddle +2" mesh="horse_harness_roman_b_new" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
+  <Item id="crpg_northern_light_harness_v3_h2" name="{=uRqm1nJ7}Light Saddle +2" mesh="horse_harness_roman_b_new" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="16" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_northern_light_harness_v2_h3" name="{=uRqm1nJ7}Light Saddle +3" mesh="horse_harness_roman_b_new" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
+  <Item id="crpg_northern_light_harness_v3_h3" name="{=uRqm1nJ7}Light Saddle +3" mesh="horse_harness_roman_b_new" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="19" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_half_barding_v2_h0" name="{=qNNja5IF}Leather Half Barding" mesh="horse_harness_khuzait_d_clotest" culture="Culture.khuzait" subtype="body_armor" weight="19" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_half_barding_v3_h0" name="{=qNNja5IF}Leather Half Barding" mesh="horse_harness_khuzait_d_clotest" culture="Culture.khuzait" subtype="body_armor" weight="19" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="19" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_khuzait_d_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_half_barding_v2_h1" name="{=qNNja5IF}Leather Half Barding +1" mesh="horse_harness_khuzait_d_clotest" culture="Culture.khuzait" subtype="body_armor" weight="19" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_half_barding_v3_h1" name="{=qNNja5IF}Leather Half Barding +1" mesh="horse_harness_khuzait_d_clotest" culture="Culture.khuzait" subtype="body_armor" weight="19" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="22" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_khuzait_d_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_half_barding_v2_h2" name="{=qNNja5IF}Leather Half Barding +2" mesh="horse_harness_khuzait_d_clotest" culture="Culture.khuzait" subtype="body_armor" weight="19" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_half_barding_v3_h2" name="{=qNNja5IF}Leather Half Barding +2" mesh="horse_harness_khuzait_d_clotest" culture="Culture.khuzait" subtype="body_armor" weight="19" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="25" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_khuzait_d_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_half_barding_v2_h3" name="{=qNNja5IF}Leather Half Barding +3" mesh="horse_harness_khuzait_d_clotest" culture="Culture.khuzait" subtype="body_armor" weight="19" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_half_barding_v3_h3" name="{=qNNja5IF}Leather Half Barding +3" mesh="horse_harness_khuzait_d_clotest" culture="Culture.khuzait" subtype="body_armor" weight="19" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="28" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_khuzait_d_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_fur_harness_v2_h0" name="{=EfRKaKs0}Steppe Fur Harness" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_fur_harness_v3_h0" name="{=EfRKaKs0}Steppe Fur Harness" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="8" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_a_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_fur_harness_v2_h1" name="{=EfRKaKs0}Steppe Fur Harness +1" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_fur_harness_v3_h1" name="{=EfRKaKs0}Steppe Fur Harness +1" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="11" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_a_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_fur_harness_v2_h2" name="{=EfRKaKs0}Steppe Fur Harness +2" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_fur_harness_v3_h2" name="{=EfRKaKs0}Steppe Fur Harness +2" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_a_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_fur_harness_v2_h3" name="{=EfRKaKs0}Steppe Fur Harness +3" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_fur_harness_v3_h3" name="{=EfRKaKs0}Steppe Fur Harness +3" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_a_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_harness_v2_h0" name="{=OaQE1Frx}Steppe Saddle" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_harness_v3_h0" name="{=OaQE1Frx}Steppe Saddle" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="7" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_b_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_harness_v2_h1" name="{=OaQE1Frx}Steppe Saddle +1" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_harness_v3_h1" name="{=OaQE1Frx}Steppe Saddle +1" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="10" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_b_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_harness_v2_h2" name="{=OaQE1Frx}Steppe Saddle +2" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_harness_v3_h2" name="{=OaQE1Frx}Steppe Saddle +2" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="13" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_b_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_steppe_harness_v2_h3" name="{=OaQE1Frx}Steppe Saddle +3" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_steppe_harness_v3_h3" name="{=OaQE1Frx}Steppe Saddle +3" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="16" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_b_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_mail_and_plate_barding_v2_h0" name="{=Vj4ZBxm5}Reinforced Plate Barding" mesh="horse_harness_aserai_c_clotest" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_mail_and_plate_barding_v3_h0" name="{=Vj4ZBxm5}Reinforced Plate Barding" mesh="horse_harness_aserai_c_clotest" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_mail_and_plate_barding_v2_h1" name="{=Vj4ZBxm5}Reinforced Plate Barding +1" mesh="horse_harness_aserai_c_clotest" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_mail_and_plate_barding_v3_h1" name="{=Vj4ZBxm5}Reinforced Plate Barding +1" mesh="horse_harness_aserai_c_clotest" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_mail_and_plate_barding_v2_h2" name="{=Vj4ZBxm5}Reinforced Plate Barding +2" mesh="horse_harness_aserai_c_clotest" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_mail_and_plate_barding_v3_h2" name="{=Vj4ZBxm5}Reinforced Plate Barding +2" mesh="horse_harness_aserai_c_clotest" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_mail_and_plate_barding_v2_h3" name="{=Vj4ZBxm5}Reinforced Plate Barding +3" mesh="horse_harness_aserai_c_clotest" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_mail_and_plate_barding_v3_h3" name="{=Vj4ZBxm5}Reinforced Plate Barding +3" mesh="horse_harness_aserai_c_clotest" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_half_mail_and_plate_barding_v2_h0" name="{=NRB3V6yP}Reinforced Half Plate Barding" mesh="horse_harness_aserai_d_clotest" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_half_mail_and_plate_barding_v3_h0" name="{=NRB3V6yP}Reinforced Half Plate Barding" mesh="horse_harness_aserai_d_clotest" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_aserai_d_rein" material_type="Plate" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_half_mail_and_plate_barding_v2_h1" name="{=NRB3V6yP}Reinforced Half Plate Barding +1" mesh="horse_harness_aserai_d_clotest" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_half_mail_and_plate_barding_v3_h1" name="{=NRB3V6yP}Reinforced Half Plate Barding +1" mesh="horse_harness_aserai_d_clotest" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_aserai_d_rein" material_type="Plate" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_half_mail_and_plate_barding_v2_h2" name="{=NRB3V6yP}Reinforced Half Plate Barding +2" mesh="horse_harness_aserai_d_clotest" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_half_mail_and_plate_barding_v3_h2" name="{=NRB3V6yP}Reinforced Half Plate Barding +2" mesh="horse_harness_aserai_d_clotest" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_aserai_d_rein" material_type="Plate" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_half_mail_and_plate_barding_v2_h3" name="{=NRB3V6yP}Reinforced Half Plate Barding +3" mesh="horse_harness_aserai_d_clotest" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_half_mail_and_plate_barding_v3_h3" name="{=NRB3V6yP}Reinforced Half Plate Barding +3" mesh="horse_harness_aserai_d_clotest" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_aserai_d_rein" material_type="Plate" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_aseran_village_harness_v2_h0" name="{=79bPUaOK}Bedouin Common Saddle" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_aseran_village_harness_v3_h0" name="{=79bPUaOK}Bedouin Common Saddle" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="7" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_aserai_b_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_aseran_village_harness_v2_h1" name="{=79bPUaOK}Bedouin Common Saddle +1" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_aseran_village_harness_v3_h1" name="{=79bPUaOK}Bedouin Common Saddle +1" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="10" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_aserai_b_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_aseran_village_harness_v2_h2" name="{=79bPUaOK}Bedouin Common Saddle +2" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_aseran_village_harness_v3_h2" name="{=79bPUaOK}Bedouin Common Saddle +2" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="13" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_aserai_b_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_aseran_village_harness_v2_h3" name="{=79bPUaOK}Bedouin Common Saddle +3" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_aseran_village_harness_v3_h3" name="{=79bPUaOK}Bedouin Common Saddle +3" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="16" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_aserai_b_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_desert_cloth_harness_v2_h0" name="{=LhUhcbzI}Bedouin Cloth Saddle" mesh="horse_harness_aserai_a_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_desert_cloth_harness_v3_h0" name="{=LhUhcbzI}Bedouin Cloth Saddle" mesh="horse_harness_aserai_a_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="7" mane_cover_type="none" reins_mesh="horse_harness_aserai_a_rein" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_desert_cloth_harness_v2_h1" name="{=LhUhcbzI}Bedouin Cloth Saddle +1" mesh="horse_harness_aserai_a_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_desert_cloth_harness_v3_h1" name="{=LhUhcbzI}Bedouin Cloth Saddle +1" mesh="horse_harness_aserai_a_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="10" mane_cover_type="none" reins_mesh="horse_harness_aserai_a_rein" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_desert_cloth_harness_v2_h2" name="{=LhUhcbzI}Bedouin Cloth Saddle +2" mesh="horse_harness_aserai_a_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_desert_cloth_harness_v3_h2" name="{=LhUhcbzI}Bedouin Cloth Saddle +2" mesh="horse_harness_aserai_a_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="13" mane_cover_type="none" reins_mesh="horse_harness_aserai_a_rein" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_desert_cloth_harness_v2_h3" name="{=LhUhcbzI}Bedouin Cloth Saddle +3" mesh="horse_harness_aserai_a_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_desert_cloth_harness_v3_h3" name="{=LhUhcbzI}Bedouin Cloth Saddle +3" mesh="horse_harness_aserai_a_clotest" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="16" mane_cover_type="none" reins_mesh="horse_harness_aserai_a_rein" family_type="1" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_studded_steppe_barding_v2_h0" name="{=LzlQUcak}Studded Leather Barding" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_studded_steppe_barding_v3_h0" name="{=LzlQUcak}Studded Leather Barding" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="22" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_studded_steppe_barding_v2_h1" name="{=LzlQUcak}Studded Leather Barding +1" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_studded_steppe_barding_v3_h1" name="{=LzlQUcak}Studded Leather Barding +1" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="25" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_studded_steppe_barding_v2_h2" name="{=LzlQUcak}Studded Leather Barding +2" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_studded_steppe_barding_v3_h2" name="{=LzlQUcak}Studded Leather Barding +2" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="28" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_studded_steppe_barding_v2_h3" name="{=LzlQUcak}Studded Leather Barding +3" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_studded_steppe_barding_v3_h3" name="{=LzlQUcak}Studded Leather Barding +3" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="31" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_imperial_scale_barding_v2_h0" name="{=ds1nrqNv}Cataphract Scale Barding" mesh="horse_harness_imperial_b_clotest" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_imperial_scale_barding_v3_h0" name="{=ds1nrqNv}Cataphract Scale Barding" mesh="horse_harness_imperial_b_clotest" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_imperial_scale_barding_v2_h1" name="{=ds1nrqNv}Cataphract Scale Barding +1" mesh="horse_harness_imperial_b_clotest" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_imperial_scale_barding_v3_h1" name="{=ds1nrqNv}Cataphract Scale Barding +1" mesh="horse_harness_imperial_b_clotest" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_imperial_scale_barding_v2_h2" name="{=ds1nrqNv}Cataphract Scale Barding +2" mesh="horse_harness_imperial_b_clotest" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_imperial_scale_barding_v3_h2" name="{=ds1nrqNv}Cataphract Scale Barding +2" mesh="horse_harness_imperial_b_clotest" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_imperial_scale_barding_v2_h3" name="{=ds1nrqNv}Cataphract Scale Barding +3" mesh="horse_harness_imperial_b_clotest" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_imperial_scale_barding_v3_h3" name="{=ds1nrqNv}Cataphract Scale Barding +3" mesh="horse_harness_imperial_b_clotest" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_half_scale_barding_v4_h0" name="{=i2QlHUVW}Cataphract Half Scale Barding" mesh="horse_harness_imperial_c_clotest" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_half_scale_barding_v5_h0" name="{=i2QlHUVW}Cataphract Half Scale Barding" mesh="horse_harness_imperial_c_clotest" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_c_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_half_scale_barding_v4_h1" name="{=i2QlHUVW}Cataphract Half Scale Barding +1" mesh="horse_harness_imperial_c_clotest" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_half_scale_barding_v5_h1" name="{=i2QlHUVW}Cataphract Half Scale Barding +1" mesh="horse_harness_imperial_c_clotest" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_c_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_half_scale_barding_v4_h2" name="{=i2QlHUVW}Cataphract Half Scale Barding +2" mesh="horse_harness_imperial_c_clotest" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_half_scale_barding_v5_h2" name="{=i2QlHUVW}Cataphract Half Scale Barding +2" mesh="horse_harness_imperial_c_clotest" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="48" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_c_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_half_scale_barding_v4_h3" name="{=i2QlHUVW}Cataphract Half Scale Barding +3" mesh="horse_harness_imperial_c_clotest" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_half_scale_barding_v5_h3" name="{=i2QlHUVW}Cataphract Half Scale Barding +3" mesh="horse_harness_imperial_c_clotest" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="51" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_c_rein" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_imperial_riding_harness_v2_h0" name="{=NUmDuEqI}Imperial Riding Harness" mesh="horse_harness_a_new" culture="Culture.empire" weight="7" appearance="1" Type="HorseHarness">
+  <Item id="crpg_imperial_riding_harness_v3_h0" name="{=NUmDuEqI}Imperial Riding Harness" mesh="horse_harness_a_new" culture="Culture.empire" weight="7" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="7" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_a_new_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_imperial_riding_harness_v2_h1" name="{=NUmDuEqI}Imperial Riding Harness +1" mesh="horse_harness_a_new" culture="Culture.empire" weight="7" appearance="1" Type="HorseHarness">
+  <Item id="crpg_imperial_riding_harness_v3_h1" name="{=NUmDuEqI}Imperial Riding Harness +1" mesh="horse_harness_a_new" culture="Culture.empire" weight="7" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="10" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_a_new_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_imperial_riding_harness_v2_h2" name="{=NUmDuEqI}Imperial Riding Harness +2" mesh="horse_harness_a_new" culture="Culture.empire" weight="7" appearance="1" Type="HorseHarness">
+  <Item id="crpg_imperial_riding_harness_v3_h2" name="{=NUmDuEqI}Imperial Riding Harness +2" mesh="horse_harness_a_new" culture="Culture.empire" weight="7" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="13" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_a_new_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_imperial_riding_harness_v2_h3" name="{=NUmDuEqI}Imperial Riding Harness +3" mesh="horse_harness_a_new" culture="Culture.empire" weight="7" appearance="1" Type="HorseHarness">
+  <Item id="crpg_imperial_riding_harness_v3_h3" name="{=NUmDuEqI}Imperial Riding Harness +3" mesh="horse_harness_a_new" culture="Culture.empire" weight="7" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="16" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_a_new_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_stripped_leather_harness_v2_h0" name="{=Yh7Dorsr}Striped Leather Harness" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_stripped_leather_harness_v3_h0" name="{=Yh7Dorsr}Striped Leather Harness" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_stripped_leather_harness_v2_h1" name="{=Yh7Dorsr}Striped Leather Harness +1" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_stripped_leather_harness_v3_h1" name="{=Yh7Dorsr}Striped Leather Harness +1" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_stripped_leather_harness_v2_h2" name="{=Yh7Dorsr}Striped Leather Harness +2" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_stripped_leather_harness_v3_h2" name="{=Yh7Dorsr}Striped Leather Harness +2" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_stripped_leather_harness_v2_h3" name="{=Yh7Dorsr}Striped Leather Harness +3" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_stripped_leather_harness_v3_h3" name="{=Yh7Dorsr}Striped Leather Harness +3" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_chain_horse_harness_v2_h0" name="{=JkxPt29i}Chain Mail Horse Armor" mesh="horse_harness_e" subtype="body_armor" weight="33" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_chain_horse_harness_v3_h0" name="{=JkxPt29i}Chain Mail Horse Armor" mesh="horse_harness_e" subtype="body_armor" weight="33" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" hair_cover_type="all" covers_head="true" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_e_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_chain_horse_harness_v2_h1" name="{=JkxPt29i}Chain Mail Horse Armor +1" mesh="horse_harness_e" subtype="body_armor" weight="33" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_chain_horse_harness_v3_h1" name="{=JkxPt29i}Chain Mail Horse Armor +1" mesh="horse_harness_e" subtype="body_armor" weight="33" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" hair_cover_type="all" covers_head="true" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_e_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_chain_horse_harness_v2_h2" name="{=JkxPt29i}Chain Mail Horse Armor +2" mesh="horse_harness_e" subtype="body_armor" weight="33" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_chain_horse_harness_v3_h2" name="{=JkxPt29i}Chain Mail Horse Armor +2" mesh="horse_harness_e" subtype="body_armor" weight="33" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" hair_cover_type="all" covers_head="true" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_e_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_chain_horse_harness_v2_h3" name="{=JkxPt29i}Chain Mail Horse Armor +3" mesh="horse_harness_e" subtype="body_armor" weight="33" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_chain_horse_harness_v3_h3" name="{=JkxPt29i}Chain Mail Horse Armor +3" mesh="horse_harness_e" subtype="body_armor" weight="33" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" hair_cover_type="all" covers_head="true" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_e_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_chain_barding_v2_h0" name="{=HJriXlcb}Reinforced Chainmail Barding" mesh="horse_harness_vlandia_a_clotest" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_chain_barding_v3_h0" name="{=HJriXlcb}Reinforced Chainmail Barding" mesh="horse_harness_vlandia_a_clotest" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_chain_barding_v2_h1" name="{=HJriXlcb}Reinforced Chainmail Barding +1" mesh="horse_harness_vlandia_a_clotest" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_chain_barding_v3_h1" name="{=HJriXlcb}Reinforced Chainmail Barding +1" mesh="horse_harness_vlandia_a_clotest" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="37" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_chain_barding_v2_h2" name="{=HJriXlcb}Reinforced Chainmail Barding +2" mesh="horse_harness_vlandia_a_clotest" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_chain_barding_v3_h2" name="{=HJriXlcb}Reinforced Chainmail Barding +2" mesh="horse_harness_vlandia_a_clotest" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="40" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_chain_barding_v2_h3" name="{=HJriXlcb}Reinforced Chainmail Barding +3" mesh="horse_harness_vlandia_a_clotest" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_chain_barding_v3_h3" name="{=HJriXlcb}Reinforced Chainmail Barding +3" mesh="horse_harness_vlandia_a_clotest" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="43" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_halfchain_barding_v2_h0" name="{=iquQ9dro}Half Mail Barding" mesh="horse_harness_vlandia_b_clotest" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_halfchain_barding_v3_h0" name="{=iquQ9dro}Half Mail Barding" mesh="horse_harness_vlandia_b_clotest" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="29" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_halfchain_barding_v2_h1" name="{=iquQ9dro}Half Mail Barding +1" mesh="horse_harness_vlandia_b_clotest" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_halfchain_barding_v3_h1" name="{=iquQ9dro}Half Mail Barding +1" mesh="horse_harness_vlandia_b_clotest" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_halfchain_barding_v2_h2" name="{=iquQ9dro}Half Mail Barding +2" mesh="horse_harness_vlandia_b_clotest" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_halfchain_barding_v3_h2" name="{=iquQ9dro}Half Mail Barding +2" mesh="horse_harness_vlandia_b_clotest" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_halfchain_barding_v2_h3" name="{=iquQ9dro}Half Mail Barding +3" mesh="horse_harness_vlandia_b_clotest" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_halfchain_barding_v3_h3" name="{=iquQ9dro}Half Mail Barding +3" mesh="horse_harness_vlandia_b_clotest" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_light_harness_v2_h0" name="{=O37kzdXO}Western Harness, Red" mesh="horse_harness_b" weight="8" appearance="1" Type="HorseHarness">
+  <Item id="crpg_light_harness_v3_h0" name="{=O37kzdXO}Western Harness, Red" mesh="horse_harness_b" weight="8" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="8" mane_cover_type="none" maneuver_bonus="0" speed_bonus="0" charge_bonus="0" family_type="1" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_light_harness_v2_h1" name="{=O37kzdXO}Western Harness, Red +1" mesh="horse_harness_b" weight="8" appearance="1" Type="HorseHarness">
+  <Item id="crpg_light_harness_v3_h1" name="{=O37kzdXO}Western Harness, Red +1" mesh="horse_harness_b" weight="8" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="11" mane_cover_type="none" maneuver_bonus="0" speed_bonus="0" charge_bonus="0" family_type="1" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_light_harness_v2_h2" name="{=O37kzdXO}Western Harness, Red +2" mesh="horse_harness_b" weight="8" appearance="1" Type="HorseHarness">
+  <Item id="crpg_light_harness_v3_h2" name="{=O37kzdXO}Western Harness, Red +2" mesh="horse_harness_b" weight="8" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="none" maneuver_bonus="0" speed_bonus="0" charge_bonus="0" family_type="1" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_light_harness_v2_h3" name="{=O37kzdXO}Western Harness, Red +3" mesh="horse_harness_b" weight="8" appearance="1" Type="HorseHarness">
+  <Item id="crpg_light_harness_v3_h3" name="{=O37kzdXO}Western Harness, Red +3" mesh="horse_harness_b" weight="8" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="none" maneuver_bonus="0" speed_bonus="0" charge_bonus="0" family_type="1" material_type="Leather" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_highland_v2_h0" name="{=CHxRDUN1}Rugged Fur Saddle" mesh="bandit_saddle_highland" culture="Culture.battania" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_highland_v3_h0" name="{=CHxRDUN1}Rugged Fur Saddle" mesh="bandit_saddle_highland" culture="Culture.battania" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_highland_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_highland_v2_h1" name="{=CHxRDUN1}Rugged Fur Saddle +1" mesh="bandit_saddle_highland" culture="Culture.battania" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_highland_v3_h1" name="{=CHxRDUN1}Rugged Fur Saddle +1" mesh="bandit_saddle_highland" culture="Culture.battania" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_highland_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_highland_v2_h2" name="{=CHxRDUN1}Rugged Fur Saddle +2" mesh="bandit_saddle_highland" culture="Culture.battania" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_highland_v3_h2" name="{=CHxRDUN1}Rugged Fur Saddle +2" mesh="bandit_saddle_highland" culture="Culture.battania" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_highland_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_highland_v2_h3" name="{=CHxRDUN1}Rugged Fur Saddle +3" mesh="bandit_saddle_highland" culture="Culture.battania" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_highland_v3_h3" name="{=CHxRDUN1}Rugged Fur Saddle +3" mesh="bandit_saddle_highland" culture="Culture.battania" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_highland_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_steppe_v2_h0" name="{=p2jR7Urm}Rugged Saddle" mesh="bandit_saddle_a" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_steppe_v3_h0" name="{=p2jR7Urm}Rugged Saddle" mesh="bandit_saddle_a" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="8" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_a_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_steppe_v2_h1" name="{=p2jR7Urm}Rugged Saddle +1" mesh="bandit_saddle_a" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_steppe_v3_h1" name="{=p2jR7Urm}Rugged Saddle +1" mesh="bandit_saddle_a" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="11" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_a_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_steppe_v2_h2" name="{=p2jR7Urm}Rugged Saddle +2" mesh="bandit_saddle_a" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_steppe_v3_h2" name="{=p2jR7Urm}Rugged Saddle +2" mesh="bandit_saddle_a" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_a_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_steppe_v2_h3" name="{=p2jR7Urm}Rugged Saddle +3" mesh="bandit_saddle_a" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_steppe_v3_h3" name="{=p2jR7Urm}Rugged Saddle +3" mesh="bandit_saddle_a" subtype="body_armor" weight="8" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_a_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_desert_v2_h0" name="{=8PXbyI2r}Rugged Bedouin Saddle" mesh="bandit_saddle_desert" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_desert_v3_h0" name="{=8PXbyI2r}Rugged Bedouin Saddle" mesh="bandit_saddle_desert" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="7" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_desert_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_desert_v2_h1" name="{=8PXbyI2r}Rugged Bedouin Saddle +1" mesh="bandit_saddle_desert" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_desert_v3_h1" name="{=8PXbyI2r}Rugged Bedouin Saddle +1" mesh="bandit_saddle_desert" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="10" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_desert_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_desert_v2_h2" name="{=8PXbyI2r}Rugged Bedouin Saddle +2" mesh="bandit_saddle_desert" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_desert_v3_h2" name="{=8PXbyI2r}Rugged Bedouin Saddle +2" mesh="bandit_saddle_desert" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="13" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_desert_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item multiplayer_item="false" id="crpg_bandit_saddle_desert_v2_h3" name="{=8PXbyI2r}Rugged Bedouin Saddle +3" mesh="bandit_saddle_desert" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item multiplayer_item="false" id="crpg_bandit_saddle_desert_v3_h3" name="{=8PXbyI2r}Rugged Bedouin Saddle +3" mesh="bandit_saddle_desert" culture="Culture.aserai" subtype="body_armor" weight="7" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="16" mane_cover_type="none" family_type="1" reins_mesh="bandit_saddle_desert_rein" material_type="Cloth" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_2_v1_h0" name="Pack Camel" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_2_v2_h0" name="Pack Camel" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="72" speed="32" charge_damage="2" body_length="100" extra_health="10" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="74" speed="28" charge_damage="2" body_length="100" extra_health="10" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_2_v1_h1" name="Pack Camel +1" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_2_v2_h1" name="Pack Camel +1" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="72" speed="33" charge_damage="2" body_length="100" extra_health="24" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="74" speed="29" charge_damage="2" body_length="100" extra_health="24" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_2_v1_h2" name="Pack Camel +2" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_2_v2_h2" name="Pack Camel +2" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="73" speed="33" charge_damage="2" body_length="100" extra_health="38" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="75" speed="29" charge_damage="2" body_length="100" extra_health="38" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_2_v1_h3" name="Pack Camel +3" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_2_v2_h3" name="Pack Camel +3" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="74" speed="33" charge_damage="2" body_length="100" extra_health="52" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="76" speed="29" charge_damage="2" body_length="100" extra_health="52" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_3_v1_h0" name="Pratihara Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_3_v2_h0" name="Pratihara Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="76" speed="33" charge_damage="3" body_length="110" extra_health="16" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="78" speed="29" charge_damage="3" body_length="110" extra_health="16" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_3_v1_h1" name="Pratihara Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_3_v2_h1" name="Pratihara Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="76" speed="34" charge_damage="3" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="78" speed="30" charge_damage="3" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_3_v1_h2" name="Pratihara Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_3_v2_h2" name="Pratihara Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="77" speed="34" charge_damage="3" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="79" speed="30" charge_damage="3" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_3_v1_h3" name="Pratihara Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_3_v2_h3" name="Pratihara Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="78" speed="34" charge_damage="3" body_length="110" extra_health="59" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="80" speed="30" charge_damage="3" body_length="110" extra_health="59" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_4_v1_h0" name="Qedarite Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_4_v2_h0" name="Qedarite Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="77" speed="34" charge_damage="4" body_length="110" extra_health="22" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="79" speed="30" charge_damage="4" body_length="110" extra_health="22" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_4_v1_h1" name="Qedarite Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_4_v2_h1" name="Qedarite Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="77" speed="35" charge_damage="4" body_length="110" extra_health="36" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="79" speed="31" charge_damage="4" body_length="110" extra_health="36" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_4_v1_h2" name="Qedarite Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_4_v2_h2" name="Qedarite Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="78" speed="35" charge_damage="4" body_length="110" extra_health="51" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="80" speed="31" charge_damage="4" body_length="110" extra_health="51" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_4_v1_h3" name="Qedarite Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_4_v2_h3" name="Qedarite Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="79" speed="35" charge_damage="4" body_length="110" extra_health="66" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="81" speed="31" charge_damage="4" body_length="110" extra_health="66" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_5_v1_h0" name="Palmyrene Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_5_v2_h0" name="Palmyrene Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="78" speed="35" charge_damage="5" body_length="110" extra_health="28" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="80" speed="31" charge_damage="5" body_length="110" extra_health="28" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_5_v1_h1" name="Palmyrene Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_5_v2_h1" name="Palmyrene Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="78" speed="36" charge_damage="5" body_length="110" extra_health="43" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="80" speed="32" charge_damage="5" body_length="110" extra_health="43" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_5_v1_h2" name="Palmyrene Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_5_v2_h2" name="Palmyrene Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="79" speed="36" charge_damage="5" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="81" speed="32" charge_damage="5" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_5_v1_h3" name="Palmyrene Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_5_v2_h3" name="Palmyrene Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="80" speed="36" charge_damage="5" body_length="110" extra_health="74" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="82" speed="32" charge_damage="5" body_length="110" extra_health="74" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_6_v1_h0" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_6_v2_h0" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="80" speed="37" charge_damage="4" body_length="100" extra_health="16" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="82" speed="33" charge_damage="4" body_length="100" extra_health="16" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_6_v1_h1" name="Sargonid Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_6_v2_h1" name="Sargonid Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="80" speed="38" charge_damage="4" body_length="100" extra_health="30" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="82" speed="34" charge_damage="4" body_length="100" extra_health="30" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_6_v1_h2" name="Sargonid Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_6_v2_h2" name="Sargonid Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="81" speed="38" charge_damage="4" body_length="100" extra_health="45" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="83" speed="34" charge_damage="4" body_length="100" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_6_v1_h3" name="Sargonid Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_6_v2_h3" name="Sargonid Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="38" charge_damage="4" body_length="100" extra_health="59" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="84" speed="34" charge_damage="4" body_length="100" extra_health="59" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_7_v1_h0" name="Sargonid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_7_v2_h0" name="Sargonid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="79" speed="36" charge_damage="6" body_length="110" extra_health="34" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="81" speed="32" charge_damage="6" body_length="110" extra_health="34" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_7_v1_h1" name="Sargonid Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_7_v2_h1" name="Sargonid Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="79" speed="37" charge_damage="6" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="81" speed="33" charge_damage="6" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_7_v1_h2" name="Sargonid Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_7_v2_h2" name="Sargonid Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="80" speed="37" charge_damage="6" body_length="110" extra_health="65" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="82" speed="33" charge_damage="6" body_length="110" extra_health="65" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_7_v1_h3" name="Sargonid Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_7_v2_h3" name="Sargonid Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="81" speed="37" charge_damage="6" body_length="110" extra_health="81" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="83" speed="33" charge_damage="6" body_length="110" extra_health="81" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_8_v1_h0" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_8_v2_h0" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="81" speed="38" charge_damage="4" body_length="100" extra_health="16" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="83" speed="34" charge_damage="4" body_length="100" extra_health="16" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_8_v1_h1" name="Nabatean Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_8_v2_h1" name="Nabatean Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="81" speed="39" charge_damage="4" body_length="100" extra_health="30" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="83" speed="35" charge_damage="4" body_length="100" extra_health="30" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_8_v1_h2" name="Nabatean Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_8_v2_h2" name="Nabatean Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="39" charge_damage="4" body_length="100" extra_health="45" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="84" speed="35" charge_damage="4" body_length="100" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_8_v1_h3" name="Nabatean Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_8_v2_h3" name="Nabatean Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="83" speed="39" charge_damage="4" body_length="100" extra_health="59" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="85" speed="35" charge_damage="4" body_length="100" extra_health="59" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_9_v1_h0" name="Nabatean Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_9_v2_h0" name="Nabatean Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="80" speed="37" charge_damage="6" body_length="110" extra_health="34" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="82" speed="33" charge_damage="6" body_length="110" extra_health="34" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_9_v1_h1" name="Nabatean Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_9_v2_h1" name="Nabatean Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="80" speed="38" charge_damage="6" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="82" speed="34" charge_damage="6" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_9_v1_h2" name="Nabatean Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_9_v2_h2" name="Nabatean Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="81" speed="38" charge_damage="6" body_length="110" extra_health="65" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="83" speed="34" charge_damage="6" body_length="110" extra_health="65" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_9_v1_h3" name="Nabatean Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_9_v2_h3" name="Nabatean Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="82" speed="38" charge_damage="6" body_length="110" extra_health="81" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="84" speed="34" charge_damage="6" body_length="110" extra_health="81" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_10_v1_h0" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_10_v2_h0" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="39" charge_damage="4" body_length="100" extra_health="25" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="84" speed="35" charge_damage="4" body_length="100" extra_health="25" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_10_v1_h1" name="Seleucid Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_10_v2_h1" name="Seleucid Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="40" charge_damage="4" body_length="100" extra_health="39" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="84" speed="36" charge_damage="4" body_length="100" extra_health="39" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_10_v1_h2" name="Seleucid Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_10_v2_h2" name="Seleucid Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="83" speed="40" charge_damage="4" body_length="100" extra_health="55" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="85" speed="36" charge_damage="4" body_length="100" extra_health="55" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_10_v1_h3" name="Seleucid Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_10_v2_h3" name="Seleucid Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="84" speed="40" charge_damage="4" body_length="100" extra_health="70" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="86" speed="36" charge_damage="4" body_length="100" extra_health="70" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_11_v1_h0" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_11_v2_h0" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="81" speed="38" charge_damage="6" body_length="110" extra_health="43" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="83" speed="34" charge_damage="6" body_length="110" extra_health="43" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_11_v1_h1" name="Seleucid Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_11_v2_h1" name="Seleucid Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="81" speed="39" charge_damage="6" body_length="110" extra_health="59" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="83" speed="35" charge_damage="6" body_length="110" extra_health="59" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_11_v1_h2" name="Seleucid Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_11_v2_h2" name="Seleucid Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="82" speed="39" charge_damage="6" body_length="110" extra_health="75" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="84" speed="35" charge_damage="6" body_length="110" extra_health="75" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_11_v1_h3" name="Seleucid Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_11_v2_h3" name="Seleucid Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.empire" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="83" speed="39" charge_damage="6" body_length="110" extra_health="92" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="85" speed="35" charge_damage="6" body_length="110" extra_health="92" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_12_v1_h0" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_12_v2_h0" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="83" speed="40" charge_damage="4" body_length="100" extra_health="25" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="85" speed="36" charge_damage="4" body_length="100" extra_health="25" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_12_v1_h1" name="Parthian Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_12_v2_h1" name="Parthian Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="83" speed="41" charge_damage="4" body_length="100" extra_health="39" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="85" speed="37" charge_damage="4" body_length="100" extra_health="39" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_12_v1_h2" name="Parthian Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_12_v2_h2" name="Parthian Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="84" speed="41" charge_damage="4" body_length="100" extra_health="55" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="86" speed="37" charge_damage="4" body_length="100" extra_health="55" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_12_v1_h3" name="Parthian Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_12_v2_h3" name="Parthian Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="85" speed="41" charge_damage="4" body_length="100" extra_health="70" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="87" speed="37" charge_damage="4" body_length="100" extra_health="70" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_13_v1_h0" name="Parthian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_13_v2_h0" name="Parthian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="82" speed="39" charge_damage="6" body_length="110" extra_health="43" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="84" speed="35" charge_damage="6" body_length="110" extra_health="43" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_13_v1_h1" name="Parthian Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_13_v2_h1" name="Parthian Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="82" speed="40" charge_damage="6" body_length="110" extra_health="59" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="84" speed="36" charge_damage="6" body_length="110" extra_health="59" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_13_v1_h2" name="Parthian Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_13_v2_h2" name="Parthian Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="83" speed="40" charge_damage="6" body_length="110" extra_health="75" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="85" speed="36" charge_damage="6" body_length="110" extra_health="75" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_13_v1_h3" name="Parthian Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_13_v2_h3" name="Parthian Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="84" speed="40" charge_damage="6" body_length="110" extra_health="92" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="86" speed="36" charge_damage="6" body_length="110" extra_health="92" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_14_v1_h0" name="Achaemenian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_14_v2_h0" name="Achaemenian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="84" speed="41" charge_damage="5" body_length="100" extra_health="34" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="86" speed="37" charge_damage="5" body_length="100" extra_health="34" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_14_v1_h1" name="Achaemenian Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_14_v2_h1" name="Achaemenian Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="84" speed="42" charge_damage="5" body_length="100" extra_health="49" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="5" body_length="100" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_14_v1_h2" name="Achaemenian Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_14_v2_h2" name="Achaemenian Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="85" speed="42" charge_damage="5" body_length="100" extra_health="65" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="87" speed="38" charge_damage="5" body_length="100" extra_health="65" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_14_v1_h3" name="Achaemenian Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_14_v2_h3" name="Achaemenian Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="86" speed="42" charge_damage="5" body_length="100" extra_health="81" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="88" speed="38" charge_damage="5" body_length="100" extra_health="81" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_15_v1_h0" name="Achaemenian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_15_v2_h0" name="Achaemenian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="83" speed="40" charge_damage="7" body_length="110" extra_health="52" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="85" speed="36" charge_damage="7" body_length="110" extra_health="52" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_15_v1_h1" name="Achaemenian Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_15_v2_h1" name="Achaemenian Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="83" speed="41" charge_damage="7" body_length="110" extra_health="68" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="85" speed="37" charge_damage="7" body_length="110" extra_health="68" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_15_v1_h2" name="Achaemenian Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_15_v2_h2" name="Achaemenian Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="84" speed="41" charge_damage="7" body_length="110" extra_health="85" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="86" speed="37" charge_damage="7" body_length="110" extra_health="85" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_15_v1_h3" name="Achaemenian Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_15_v2_h3" name="Achaemenian Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="85" speed="41" charge_damage="7" body_length="110" extra_health="102" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="87" speed="37" charge_damage="7" body_length="110" extra_health="102" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_16_v2_h0" name="Safinat al-Barr Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_16_v3_h0" name="Safinat al-Barr Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="84" speed="40" charge_damage="8" body_length="110" extra_health="52" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="86" speed="36" charge_damage="8" body_length="110" extra_health="52" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_16_v2_h1" name="Safinat al-Barr Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_16_v3_h1" name="Safinat al-Barr Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="84" speed="41" charge_damage="8" body_length="110" extra_health="68" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="86" speed="37" charge_damage="8" body_length="110" extra_health="68" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_16_v2_h2" name="Safinat al-Barr Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_16_v3_h2" name="Safinat al-Barr Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="85" speed="41" charge_damage="8" body_length="110" extra_health="85" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="87" speed="37" charge_damage="8" body_length="110" extra_health="85" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_16_v2_h3" name="Safinat al-Barr Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_16_v3_h3" name="Safinat al-Barr Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="86" speed="41" charge_damage="8" body_length="110" extra_health="102" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="88" speed="37" charge_damage="8" body_length="110" extra_health="102" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_17_v2_h0" name="Padishah Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_17_v3_h0" name="Padishah Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="85" speed="41" charge_damage="8" body_length="110" extra_health="52" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="87" speed="37" charge_damage="8" body_length="110" extra_health="52" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_17_v2_h1" name="Padishah Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_17_v3_h1" name="Padishah Heavy Camel +1" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="85" speed="42" charge_damage="8" body_length="110" extra_health="68" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="87" speed="38" charge_damage="8" body_length="110" extra_health="68" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_17_v2_h2" name="Padishah Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_17_v3_h2" name="Padishah Heavy Camel +2" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="86" speed="42" charge_damage="8" body_length="110" extra_health="85" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="88" speed="38" charge_damage="8" body_length="110" extra_health="85" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_17_v2_h3" name="Padishah Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_17_v3_h3" name="Padishah Heavy Camel +3" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel_110" maneuver="87" speed="42" charge_damage="8" body_length="110" extra_health="102" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel_110" maneuver="89" speed="38" charge_damage="8" body_length="110" extra_health="102" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_18_v1_h0" name="Sayidat al-Sahra Light Camel" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_18_v2_h0" name="Sayidat al-Sahra Light Camel" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="84" speed="42" charge_damage="6" body_length="100" extra_health="34" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="6" body_length="100" extra_health="34" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_18_v1_h1" name="Sayidat al-Sahra Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_18_v2_h1" name="Sayidat al-Sahra Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="84" speed="43" charge_damage="6" body_length="100" extra_health="49" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="86" speed="39" charge_damage="6" body_length="100" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_18_v1_h2" name="Sayidat al-Sahra Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_18_v2_h2" name="Sayidat al-Sahra Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="85" speed="43" charge_damage="6" body_length="100" extra_health="65" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="87" speed="39" charge_damage="6" body_length="100" extra_health="65" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_18_v1_h3" name="Sayidat al-Sahra Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_18_v2_h3" name="Sayidat al-Sahra Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="86" speed="43" charge_damage="6" body_length="100" extra_health="81" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="88" speed="39" charge_damage="6" body_length="100" extra_health="81" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_19_v1_h0" name="Naqa al-Fahia Light Camel" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_19_v2_h0" name="Naqa al-Fahia Light Camel" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="85" speed="43" charge_damage="6" body_length="100" extra_health="34" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="87" speed="39" charge_damage="6" body_length="100" extra_health="34" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_19_v1_h1" name="Naqa al-Fahia Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_19_v2_h1" name="Naqa al-Fahia Light Camel +1" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="85" speed="44" charge_damage="6" body_length="100" extra_health="49" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="87" speed="40" charge_damage="6" body_length="100" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_19_v1_h2" name="Naqa al-Fahia Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_19_v2_h2" name="Naqa al-Fahia Light Camel +2" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="86" speed="44" charge_damage="6" body_length="100" extra_health="65" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="88" speed="40" charge_damage="6" body_length="100" extra_health="65" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_camel_19_v1_h3" name="Naqa al-Fahia Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
+  <Item id="crpg_mount1_camel_19_v2_h3" name="Naqa al-Fahia Light Camel +3" mesh="camel_mesh" item_category="sumpter_horse" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="87" speed="44" charge_damage="6" body_length="100" extra_health="81" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="89" speed="40" charge_damage="6" body_length="100" extra_health="81" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mule1_2_v1_h0" name="Chadz" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule1_2_v2_h0" name="Chadz" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.mule_92" maneuver="60" speed="33" charge_damage="1" body_length="92" is_mountable="true" extra_health="164" is_pack_animal="true" />
+      <Horse monster="Monster.mule_92" maneuver="62" speed="29" charge_damage="1" body_length="92" is_mountable="true" extra_health="164" is_pack_animal="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mule1_2_v1_h1" name="Chadz +1" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule1_2_v2_h1" name="Chadz +1" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.mule_92" maneuver="60" speed="34" charge_damage="1" body_length="92" is_mountable="true" extra_health="187" is_pack_animal="true" />
+      <Horse monster="Monster.mule_92" maneuver="62" speed="30" charge_damage="1" body_length="92" is_mountable="true" extra_health="187" is_pack_animal="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mule1_2_v1_h2" name="Chadz +2" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule1_2_v2_h2" name="Chadz +2" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.mule_92" maneuver="61" speed="34" charge_damage="1" body_length="92" is_mountable="true" extra_health="212" is_pack_animal="true" />
+      <Horse monster="Monster.mule_92" maneuver="63" speed="30" charge_damage="1" body_length="92" is_mountable="true" extra_health="212" is_pack_animal="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mule1_2_v1_h3" name="Chadz +3" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule1_2_v2_h3" name="Chadz +3" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.mule_92" maneuver="62" speed="34" charge_damage="1" body_length="92" is_mountable="true" extra_health="237" is_pack_animal="true" />
+      <Horse monster="Monster.mule_92" maneuver="64" speed="30" charge_damage="1" body_length="92" is_mountable="true" extra_health="237" is_pack_animal="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mule1_1_v1_h0" name="Mule" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule1_1_v2_h0" name="Mule" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.mule_92" maneuver="58" speed="30" charge_damage="0" body_length="92" is_mountable="true" extra_health="98" is_pack_animal="true" />
+      <Horse monster="Monster.mule_92" maneuver="60" speed="26" charge_damage="0" body_length="92" is_mountable="true" extra_health="98" is_pack_animal="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mule1_1_v1_h1" name="Mule +1" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule1_1_v2_h1" name="Mule +1" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.mule_92" maneuver="58" speed="31" charge_damage="0" body_length="92" is_mountable="true" extra_health="117" is_pack_animal="true" />
+      <Horse monster="Monster.mule_92" maneuver="60" speed="27" charge_damage="0" body_length="92" is_mountable="true" extra_health="117" is_pack_animal="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mule1_1_v1_h2" name="Mule +2" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule1_1_v2_h2" name="Mule +2" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.mule_92" maneuver="59" speed="31" charge_damage="0" body_length="92" is_mountable="true" extra_health="137" is_pack_animal="true" />
+      <Horse monster="Monster.mule_92" maneuver="61" speed="27" charge_damage="0" body_length="92" is_mountable="true" extra_health="137" is_pack_animal="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mule1_1_v1_h3" name="Mule +3" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule1_1_v2_h3" name="Mule +3" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.mule_92" maneuver="60" speed="31" charge_damage="0" body_length="92" is_mountable="true" extra_health="158" is_pack_animal="true" />
+      <Horse monster="Monster.mule_92" maneuver="62" speed="27" charge_damage="0" body_length="92" is_mountable="true" extra_health="158" is_pack_animal="true" />
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_5_v1_h0" name="Irish Hobby" mesh="horse_brown" item_category="noble_horse" culture="Culture.battania" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_5_v2_h0" name="Irish Hobby" mesh="horse_brown" item_category="noble_horse" culture="Culture.battania" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="74" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="-29" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="76" speed="34" charge_damage="2" body_length="95" is_mountable="true" extra_health="-29" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1017,9 +1017,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_5_v1_h1" name="Irish Hobby +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.battania" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_5_v2_h1" name="Irish Hobby +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.battania" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="74" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-18" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="76" speed="35" charge_damage="2" body_length="95" is_mountable="true" extra_health="-18" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1034,9 +1034,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_5_v1_h2" name="Irish Hobby +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.battania" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_5_v2_h2" name="Irish Hobby +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.battania" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="75" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-6" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="77" speed="35" charge_damage="2" body_length="95" is_mountable="true" extra_health="-6" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1051,9 +1051,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_5_v1_h3" name="Irish Hobby +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.battania" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_5_v2_h3" name="Irish Hobby +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.battania" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="76" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="5" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="78" speed="35" charge_damage="2" body_length="95" is_mountable="true" extra_health="5" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1068,9 +1068,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_6_v1_h0" name="Caspian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_6_v2_h0" name="Caspian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="76" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-26" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="78" speed="35" charge_damage="2" body_length="95" is_mountable="true" extra_health="-26" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1085,9 +1085,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_6_v1_h1" name="Caspian Palfrey +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_6_v2_h1" name="Caspian Palfrey +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="76" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-15" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="78" speed="36" charge_damage="2" body_length="95" is_mountable="true" extra_health="-15" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1102,9 +1102,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_6_v1_h2" name="Caspian Palfrey +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_6_v2_h2" name="Caspian Palfrey +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="77" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-3" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="79" speed="36" charge_damage="2" body_length="95" is_mountable="true" extra_health="-3" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1119,9 +1119,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_6_v1_h3" name="Caspian Palfrey +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_6_v2_h3" name="Caspian Palfrey +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="78" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="9" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="80" speed="36" charge_damage="2" body_length="95" is_mountable="true" extra_health="9" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1136,9 +1136,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_7_v1_h0" name="Marwari Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_7_v2_h0" name="Marwari Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="78" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-23" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="80" speed="36" charge_damage="2" body_length="95" is_mountable="true" extra_health="-23" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1153,9 +1153,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_7_v1_h1" name="Marwari Palfrey +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_7_v2_h1" name="Marwari Palfrey +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="78" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-12" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="80" speed="37" charge_damage="2" body_length="95" is_mountable="true" extra_health="-12" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1170,9 +1170,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_7_v1_h2" name="Marwari Palfrey +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_7_v2_h2" name="Marwari Palfrey +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="79" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="81" speed="37" charge_damage="2" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1187,9 +1187,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_7_v1_h3" name="Marwari Palfrey +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_7_v2_h3" name="Marwari Palfrey +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="80" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="13" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="82" speed="37" charge_damage="2" body_length="95" is_mountable="true" extra_health="13" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1204,9 +1204,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_8_v1_h0" name="Moroccan Barb" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_8_v2_h0" name="Moroccan Barb" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="80" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="82" speed="37" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1221,9 +1221,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_8_v1_h1" name="Moroccan Barb +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_8_v2_h1" name="Moroccan Barb +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="80" speed="42" charge_damage="2" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="82" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1238,9 +1238,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_8_v1_h2" name="Moroccan Barb +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_8_v2_h2" name="Moroccan Barb +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="81" speed="42" charge_damage="2" body_length="95" is_mountable="true" extra_health="4" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="83" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="4" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1255,9 +1255,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_8_v1_h3" name="Moroccan Barb +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_8_v2_h3" name="Moroccan Barb +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="82" speed="42" charge_damage="2" body_length="95" is_mountable="true" extra_health="16" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="84" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="16" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1272,9 +1272,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_9_v1_h0" name="Morvandiau Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_9_v2_h0" name="Morvandiau Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="82" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="84" speed="38" charge_damage="3" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1289,9 +1289,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_9_v1_h1" name="Morvandiau Palfrey +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_9_v2_h1" name="Morvandiau Palfrey +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="82" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="84" speed="39" charge_damage="3" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1306,9 +1306,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_9_v1_h2" name="Morvandiau Palfrey +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_9_v2_h2" name="Morvandiau Palfrey +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="83" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="7" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="85" speed="39" charge_damage="3" body_length="95" is_mountable="true" extra_health="7" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1323,9 +1323,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_9_v1_h3" name="Morvandiau Palfrey +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_9_v2_h3" name="Morvandiau Palfrey +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="84" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="20" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="86" speed="39" charge_damage="3" body_length="95" is_mountable="true" extra_health="20" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1340,9 +1340,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_10_v1_h0" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_10_v2_h0" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="83" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="85" speed="39" charge_damage="3" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1357,9 +1357,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_10_v1_h1" name="Berber Jennet +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_10_v2_h1" name="Berber Jennet +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="83" speed="44" charge_damage="3" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="85" speed="40" charge_damage="3" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1374,9 +1374,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_10_v1_h2" name="Berber Jennet +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_10_v2_h2" name="Berber Jennet +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="84" speed="44" charge_damage="3" body_length="95" is_mountable="true" extra_health="11" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="86" speed="40" charge_damage="3" body_length="95" is_mountable="true" extra_health="11" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1391,9 +1391,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_10_v1_h3" name="Berber Jennet +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_10_v2_h3" name="Berber Jennet +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="85" speed="44" charge_damage="3" body_length="95" is_mountable="true" extra_health="23" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="87" speed="40" charge_damage="3" body_length="95" is_mountable="true" extra_health="23" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1408,9 +1408,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_11_v1_h0" name="Tchenarani Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_11_v2_h0" name="Tchenarani Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="84" speed="43" charge_damage="4" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="86" speed="39" charge_damage="4" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1425,9 +1425,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_11_v1_h1" name="Tchenarani Palfrey +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_11_v2_h1" name="Tchenarani Palfrey +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="84" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="86" speed="40" charge_damage="4" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1442,9 +1442,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_11_v1_h2" name="Tchenarani Palfrey +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_11_v2_h2" name="Tchenarani Palfrey +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="14" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="87" speed="40" charge_damage="4" body_length="95" is_mountable="true" extra_health="14" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1459,9 +1459,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_11_v1_h3" name="Tchenarani Palfrey +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_11_v2_h3" name="Tchenarani Palfrey +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="86" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="27" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="88" speed="40" charge_damage="4" body_length="95" is_mountable="true" extra_health="27" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1476,9 +1476,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_12_v1_h0" name="Asil Purebred Arabian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_12_v2_h0" name="Asil Purebred Arabian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="87" speed="40" charge_damage="4" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1493,9 +1493,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_12_v1_h1" name="Asil Purebred Arabian Palfrey +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_12_v2_h1" name="Asil Purebred Arabian Palfrey +1" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="85" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="4" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="87" speed="41" charge_damage="4" body_length="95" is_mountable="true" extra_health="4" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1510,9 +1510,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_12_v1_h2" name="Asil Purebred Arabian Palfrey +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_12_v2_h2" name="Asil Purebred Arabian Palfrey +2" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="86" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="17" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="88" speed="41" charge_damage="4" body_length="95" is_mountable="true" extra_health="17" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1527,9 +1527,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_12_v1_h3" name="Asil Purebred Arabian Palfrey +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_12_v2_h3" name="Asil Purebred Arabian Palfrey +3" mesh="horse_brown" item_category="noble_horse" culture="Culture.aserai" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="87" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="31" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="89" speed="41" charge_damage="4" body_length="95" is_mountable="true" extra_health="31" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1544,9 +1544,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_13_v1_h0" name="Marengo Palfrey" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_13_v2_h0" name="Marengo Palfrey" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="86" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="88" speed="41" charge_damage="4" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1561,9 +1561,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_13_v1_h1" name="Marengo Palfrey +1" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_13_v2_h1" name="Marengo Palfrey +1" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="86" speed="46" charge_damage="4" body_length="95" is_mountable="true" extra_health="8" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="88" speed="42" charge_damage="4" body_length="95" is_mountable="true" extra_health="8" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1578,9 +1578,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_13_v1_h2" name="Marengo Palfrey +2" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_13_v2_h2" name="Marengo Palfrey +2" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="87" speed="46" charge_damage="4" body_length="95" is_mountable="true" extra_health="21" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="89" speed="42" charge_damage="4" body_length="95" is_mountable="true" extra_health="21" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1595,9 +1595,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_13_v1_h3" name="Marengo Palfrey +3" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_13_v2_h3" name="Marengo Palfrey +3" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="88" speed="46" charge_damage="4" body_length="95" is_mountable="true" extra_health="34" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="90" speed="42" charge_damage="4" body_length="95" is_mountable="true" extra_health="34" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1612,9 +1612,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_14_v1_h0" name="Baucent Palfrey" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_14_v2_h0" name="Baucent Palfrey" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="86" speed="46" charge_damage="5" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="88" speed="42" charge_damage="5" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1629,9 +1629,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_14_v1_h1" name="Baucent Palfrey +1" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_14_v2_h1" name="Baucent Palfrey +1" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="86" speed="47" charge_damage="5" body_length="95" is_mountable="true" extra_health="11" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="88" speed="43" charge_damage="5" body_length="95" is_mountable="true" extra_health="11" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1646,9 +1646,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_14_v1_h2" name="Baucent Palfrey +2" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_14_v2_h2" name="Baucent Palfrey +2" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="87" speed="47" charge_damage="5" body_length="95" is_mountable="true" extra_health="24" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="89" speed="43" charge_damage="5" body_length="95" is_mountable="true" extra_health="24" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1663,9 +1663,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_maneuverable_14_v1_h3" name="Baucent Palfrey +3" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_14_v2_h3" name="Baucent Palfrey +3" mesh="horse_brown" item_category="noble_horse" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_95" maneuver="88" speed="47" charge_damage="5" body_length="95" is_mountable="true" extra_health="38" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse_95" maneuver="90" speed="43" charge_damage="5" body_length="95" is_mountable="true" extra_health="38" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1680,9 +1680,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_5_v1_h0" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_5_v2_h0" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="70" speed="37" charge_damage="4" body_length="102" is_mountable="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="72" speed="33" charge_damage="4" body_length="102" is_mountable="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1697,9 +1697,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_5_v1_h1" name="Murgese Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_5_v2_h1" name="Murgese Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="70" speed="38" charge_damage="4" body_length="102" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="72" speed="34" charge_damage="4" body_length="102" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1714,9 +1714,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_5_v1_h2" name="Murgese Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_5_v2_h2" name="Murgese Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="71" speed="38" charge_damage="4" body_length="102" is_mountable="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="73" speed="34" charge_damage="4" body_length="102" is_mountable="true" extra_health="17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1731,9 +1731,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_5_v1_h3" name="Murgese Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_5_v2_h3" name="Murgese Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="72" speed="38" charge_damage="4" body_length="102" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="74" speed="34" charge_damage="4" body_length="102" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1748,9 +1748,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_6_v1_h0" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_6_v2_h0" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="72" speed="38" charge_damage="4" body_length="102" is_mountable="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="74" speed="34" charge_damage="4" body_length="102" is_mountable="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1765,9 +1765,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_6_v1_h1" name="Holsteiner Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_6_v2_h1" name="Holsteiner Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="72" speed="39" charge_damage="4" body_length="102" is_mountable="true" extra_health="8" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="74" speed="35" charge_damage="4" body_length="102" is_mountable="true" extra_health="8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1782,9 +1782,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_6_v1_h2" name="Holsteiner Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_6_v2_h2" name="Holsteiner Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="73" speed="39" charge_damage="4" body_length="102" is_mountable="true" extra_health="21" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="75" speed="35" charge_damage="4" body_length="102" is_mountable="true" extra_health="21" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1799,9 +1799,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_6_v1_h3" name="Holsteiner Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_6_v2_h3" name="Holsteiner Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="74" speed="39" charge_damage="4" body_length="102" is_mountable="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="76" speed="35" charge_damage="4" body_length="102" is_mountable="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1816,9 +1816,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_7_v1_h0" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.aserai" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_7_v2_h0" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.aserai" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="74" speed="39" charge_damage="5" body_length="102" is_mountable="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="76" speed="35" charge_damage="5" body_length="102" is_mountable="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1833,9 +1833,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_7_v1_h1" name="Kathiawadi Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.aserai" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_7_v2_h1" name="Kathiawadi Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.aserai" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="74" speed="40" charge_damage="5" body_length="102" is_mountable="true" extra_health="11" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="76" speed="36" charge_damage="5" body_length="102" is_mountable="true" extra_health="11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1850,9 +1850,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_7_v1_h2" name="Kathiawadi Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.aserai" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_7_v2_h2" name="Kathiawadi Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.aserai" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="75" speed="40" charge_damage="5" body_length="102" is_mountable="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="77" speed="36" charge_damage="5" body_length="102" is_mountable="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1867,9 +1867,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_7_v1_h3" name="Kathiawadi Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.aserai" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_7_v2_h3" name="Kathiawadi Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.aserai" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="76" speed="40" charge_damage="5" body_length="102" is_mountable="true" extra_health="38" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="78" speed="36" charge_damage="5" body_length="102" is_mountable="true" extra_health="38" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1884,9 +1884,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_8_v1_h0" name="Friesian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_8_v2_h0" name="Friesian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="76" speed="40" charge_damage="5" body_length="102" is_mountable="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="78" speed="36" charge_damage="5" body_length="102" is_mountable="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1901,9 +1901,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_8_v1_h1" name="Friesian Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_8_v2_h1" name="Friesian Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="76" speed="41" charge_damage="5" body_length="102" is_mountable="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="78" speed="37" charge_damage="5" body_length="102" is_mountable="true" extra_health="14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1918,9 +1918,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_8_v1_h2" name="Friesian Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_8_v2_h2" name="Friesian Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="77" speed="41" charge_damage="5" body_length="102" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="79" speed="37" charge_damage="5" body_length="102" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1935,9 +1935,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_8_v1_h3" name="Friesian Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_8_v2_h3" name="Friesian Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="78" speed="41" charge_damage="5" body_length="102" is_mountable="true" extra_health="41" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="80" speed="37" charge_damage="5" body_length="102" is_mountable="true" extra_health="41" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1952,9 +1952,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_9_v1_h0" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_9_v2_h0" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="78" speed="41" charge_damage="6" body_length="102" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="80" speed="37" charge_damage="6" body_length="102" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1969,9 +1969,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_9_v1_h1" name="Carthusian Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_9_v2_h1" name="Carthusian Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="78" speed="42" charge_damage="6" body_length="102" is_mountable="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="80" speed="38" charge_damage="6" body_length="102" is_mountable="true" extra_health="17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1986,9 +1986,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_9_v1_h2" name="Carthusian Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_9_v2_h2" name="Carthusian Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="79" speed="42" charge_damage="6" body_length="102" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="81" speed="38" charge_damage="6" body_length="102" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2003,9 +2003,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_9_v1_h3" name="Carthusian Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_9_v2_h3" name="Carthusian Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="80" speed="42" charge_damage="6" body_length="102" is_mountable="true" extra_health="45" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="82" speed="38" charge_damage="6" body_length="102" is_mountable="true" extra_health="45" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2020,9 +2020,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_10_v1_h0" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_10_v2_h0" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="79" speed="42" charge_damage="6" body_length="102" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="81" speed="38" charge_damage="6" body_length="102" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2037,9 +2037,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_10_v1_h1" name="Yunnan Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_10_v2_h1" name="Yunnan Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="79" speed="43" charge_damage="6" body_length="102" is_mountable="true" extra_health="20" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="81" speed="39" charge_damage="6" body_length="102" is_mountable="true" extra_health="20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2054,9 +2054,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_10_v1_h2" name="Yunnan Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_10_v2_h2" name="Yunnan Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="80" speed="43" charge_damage="6" body_length="102" is_mountable="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="82" speed="39" charge_damage="6" body_length="102" is_mountable="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2071,9 +2071,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_10_v1_h3" name="Yunnan Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_10_v2_h3" name="Yunnan Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="81" speed="43" charge_damage="6" body_length="102" is_mountable="true" extra_health="48" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="83" speed="39" charge_damage="6" body_length="102" is_mountable="true" extra_health="48" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2088,9 +2088,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_11_v1_h0" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_11_v2_h0" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="80" speed="42" charge_damage="7" body_length="102" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="82" speed="38" charge_damage="7" body_length="102" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2105,9 +2105,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_11_v1_h1" name="Auvergne Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_11_v2_h1" name="Auvergne Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="80" speed="43" charge_damage="7" body_length="102" is_mountable="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="82" speed="39" charge_damage="7" body_length="102" is_mountable="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2122,9 +2122,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_11_v1_h2" name="Auvergne Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_11_v2_h2" name="Auvergne Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="81" speed="43" charge_damage="7" body_length="102" is_mountable="true" extra_health="38" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="83" speed="39" charge_damage="7" body_length="102" is_mountable="true" extra_health="38" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2139,9 +2139,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_11_v1_h3" name="Auvergne Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_11_v2_h3" name="Auvergne Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="82" speed="43" charge_damage="7" body_length="102" is_mountable="true" extra_health="52" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="84" speed="39" charge_damage="7" body_length="102" is_mountable="true" extra_health="52" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2156,9 +2156,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_12_v1_h0" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_12_v2_h0" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="81" speed="43" charge_damage="7" body_length="102" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="83" speed="39" charge_damage="7" body_length="102" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2173,9 +2173,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_12_v1_h1" name="Lusitano Pureblood Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_12_v2_h1" name="Lusitano Pureblood Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="81" speed="44" charge_damage="7" body_length="102" is_mountable="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="83" speed="40" charge_damage="7" body_length="102" is_mountable="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2190,9 +2190,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_12_v1_h2" name="Lusitano Pureblood Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_12_v2_h2" name="Lusitano Pureblood Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="82" speed="44" charge_damage="7" body_length="102" is_mountable="true" extra_health="41" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="84" speed="40" charge_damage="7" body_length="102" is_mountable="true" extra_health="41" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2207,9 +2207,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_12_v1_h3" name="Lusitano Pureblood Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_12_v2_h3" name="Lusitano Pureblood Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="83" speed="44" charge_damage="7" body_length="102" is_mountable="true" extra_health="56" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="85" speed="40" charge_damage="7" body_length="102" is_mountable="true" extra_health="56" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2224,9 +2224,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_13_v1_h0" name="Bohemond Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_13_v2_h0" name="Bohemond Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="82" speed="44" charge_damage="8" body_length="102" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="84" speed="40" charge_damage="8" body_length="102" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2241,9 +2241,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_13_v1_h1" name="Bohemond Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_13_v2_h1" name="Bohemond Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="82" speed="45" charge_damage="8" body_length="102" is_mountable="true" extra_health="30" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="84" speed="41" charge_damage="8" body_length="102" is_mountable="true" extra_health="30" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2258,9 +2258,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_13_v1_h2" name="Bohemond Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_13_v2_h2" name="Bohemond Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="83" speed="45" charge_damage="8" body_length="102" is_mountable="true" extra_health="45" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="85" speed="41" charge_damage="8" body_length="102" is_mountable="true" extra_health="45" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2275,9 +2275,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_13_v1_h3" name="Bohemond Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_13_v2_h3" name="Bohemond Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="84" speed="45" charge_damage="8" body_length="102" is_mountable="true" extra_health="59" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="86" speed="41" charge_damage="8" body_length="102" is_mountable="true" extra_health="59" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2292,9 +2292,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_14_v1_h0" name="Llamrei Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_14_v2_h0" name="Llamrei Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="82" speed="45" charge_damage="8" body_length="102" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="84" speed="41" charge_damage="8" body_length="102" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2309,9 +2309,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_14_v1_h1" name="Llamrei Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_14_v2_h1" name="Llamrei Destrier +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="82" speed="46" charge_damage="8" body_length="102" is_mountable="true" extra_health="33" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="84" speed="42" charge_damage="8" body_length="102" is_mountable="true" extra_health="33" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2326,9 +2326,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_14_v1_h2" name="Llamrei Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_14_v2_h2" name="Llamrei Destrier +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="83" speed="46" charge_damage="8" body_length="102" is_mountable="true" extra_health="48" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="85" speed="42" charge_damage="8" body_length="102" is_mountable="true" extra_health="48" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2343,9 +2343,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_balanced_14_v1_h3" name="Llamrei Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_14_v2_h3" name="Llamrei Destrier +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_102" maneuver="84" speed="46" charge_damage="8" body_length="102" is_mountable="true" extra_health="63" modifier_group="horse">
+      <Horse monster="Monster.horse_102" maneuver="86" speed="42" charge_damage="8" body_length="102" is_mountable="true" extra_health="63" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2360,9 +2360,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_5_v1_h0" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_5_v2_h0" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="64" speed="39" charge_damage="3" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="66" speed="35" charge_damage="3" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2377,9 +2377,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_5_v1_h1" name="Norwegian Fjord Draught +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_5_v2_h1" name="Norwegian Fjord Draught +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="64" speed="40" charge_damage="3" body_length="105" is_mountable="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="66" speed="36" charge_damage="3" body_length="105" is_mountable="true" extra_health="17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2394,9 +2394,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_5_v1_h2" name="Norwegian Fjord Draught +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_5_v2_h2" name="Norwegian Fjord Draught +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="65" speed="40" charge_damage="3" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="67" speed="36" charge_damage="3" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2411,9 +2411,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_5_v1_h3" name="Norwegian Fjord Draught +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_5_v2_h3" name="Norwegian Fjord Draught +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="66" speed="40" charge_damage="3" body_length="105" is_mountable="true" extra_health="45" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="68" speed="36" charge_damage="3" body_length="105" is_mountable="true" extra_health="45" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2428,9 +2428,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_6_v1_h0" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_6_v2_h0" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="66" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="68" speed="36" charge_damage="4" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2445,9 +2445,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_6_v1_h1" name="Icelandic Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_6_v2_h1" name="Icelandic Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="66" speed="41" charge_damage="4" body_length="105" is_mountable="true" extra_health="20" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="68" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2462,9 +2462,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_6_v1_h2" name="Icelandic Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_6_v2_h2" name="Icelandic Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="67" speed="41" charge_damage="4" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="69" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2479,9 +2479,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_6_v1_h3" name="Icelandic Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_6_v2_h3" name="Icelandic Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.sturgia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="68" speed="41" charge_damage="4" body_length="105" is_mountable="true" extra_health="48" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="70" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="48" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2496,9 +2496,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_7_v1_h0" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_7_v2_h0" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="68" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="70" speed="37" charge_damage="5" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2513,9 +2513,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_7_v1_h1" name="Shire Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_7_v2_h1" name="Shire Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="68" speed="42" charge_damage="5" body_length="105" is_mountable="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="70" speed="38" charge_damage="5" body_length="105" is_mountable="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2530,9 +2530,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_7_v1_h2" name="Shire Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_7_v2_h2" name="Shire Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="69" speed="42" charge_damage="5" body_length="105" is_mountable="true" extra_health="38" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="71" speed="38" charge_damage="5" body_length="105" is_mountable="true" extra_health="38" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2547,9 +2547,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_7_v1_h3" name="Shire Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_7_v2_h3" name="Shire Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="70" speed="42" charge_damage="5" body_length="105" is_mountable="true" extra_health="52" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="72" speed="38" charge_damage="5" body_length="105" is_mountable="true" extra_health="52" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2564,9 +2564,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_8_v1_h0" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_8_v2_h0" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="70" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="72" speed="38" charge_damage="6" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2581,9 +2581,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_8_v1_h1" name="Ardennes Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_8_v2_h1" name="Ardennes Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="70" speed="43" charge_damage="6" body_length="105" is_mountable="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="72" speed="39" charge_damage="6" body_length="105" is_mountable="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2598,9 +2598,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_8_v1_h2" name="Ardennes Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_8_v2_h2" name="Ardennes Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="71" speed="43" charge_damage="6" body_length="105" is_mountable="true" extra_health="41" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="73" speed="39" charge_damage="6" body_length="105" is_mountable="true" extra_health="41" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2615,9 +2615,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_8_v1_h3" name="Ardennes Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_8_v2_h3" name="Ardennes Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="72" speed="43" charge_damage="6" body_length="105" is_mountable="true" extra_health="56" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="74" speed="39" charge_damage="6" body_length="105" is_mountable="true" extra_health="56" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2632,9 +2632,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_9_v1_h0" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_9_v2_h0" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="72" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="74" speed="39" charge_damage="7" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2649,9 +2649,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_9_v1_h1" name="Andalusian Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_9_v2_h1" name="Andalusian Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="72" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="30" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="74" speed="40" charge_damage="7" body_length="105" is_mountable="true" extra_health="30" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2666,9 +2666,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_9_v1_h2" name="Andalusian Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_9_v2_h2" name="Andalusian Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="73" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="45" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="75" speed="40" charge_damage="7" body_length="105" is_mountable="true" extra_health="45" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2683,9 +2683,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_9_v1_h3" name="Andalusian Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_9_v2_h3" name="Andalusian Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="74" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="59" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="76" speed="40" charge_damage="7" body_length="105" is_mountable="true" extra_health="59" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2700,9 +2700,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_10_v1_h0" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_10_v2_h0" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="73" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="75" speed="40" charge_damage="7" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2717,9 +2717,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_10_v1_h1" name="Desert Norman Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_10_v2_h1" name="Desert Norman Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="73" speed="45" charge_damage="7" body_length="105" is_mountable="true" extra_health="33" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="75" speed="41" charge_damage="7" body_length="105" is_mountable="true" extra_health="33" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2734,9 +2734,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_10_v1_h2" name="Desert Norman Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_10_v2_h2" name="Desert Norman Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="74" speed="45" charge_damage="7" body_length="105" is_mountable="true" extra_health="48" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="76" speed="41" charge_damage="7" body_length="105" is_mountable="true" extra_health="48" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2751,9 +2751,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_10_v1_h3" name="Desert Norman Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_10_v2_h3" name="Desert Norman Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="75" speed="45" charge_damage="7" body_length="105" is_mountable="true" extra_health="63" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="77" speed="41" charge_damage="7" body_length="105" is_mountable="true" extra_health="63" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2768,9 +2768,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_11_v1_h0" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_11_v2_h0" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="74" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="76" speed="40" charge_damage="8" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2785,9 +2785,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_11_v1_h1" name="Andravida Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_11_v2_h1" name="Andravida Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="74" speed="45" charge_damage="8" body_length="105" is_mountable="true" extra_health="36" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="76" speed="41" charge_damage="8" body_length="105" is_mountable="true" extra_health="36" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2802,9 +2802,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_11_v1_h2" name="Andravida Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_11_v2_h2" name="Andravida Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="75" speed="45" charge_damage="8" body_length="105" is_mountable="true" extra_health="51" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="77" speed="41" charge_damage="8" body_length="105" is_mountable="true" extra_health="51" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2819,9 +2819,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_11_v1_h3" name="Andravida Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_11_v2_h3" name="Andravida Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="76" speed="45" charge_damage="8" body_length="105" is_mountable="true" extra_health="66" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="78" speed="41" charge_damage="8" body_length="105" is_mountable="true" extra_health="66" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2836,9 +2836,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_12_v1_h0" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_12_v2_h0" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="75" speed="45" charge_damage="8" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="77" speed="41" charge_damage="8" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2853,9 +2853,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_12_v1_h1" name="Neapolitan Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_12_v2_h1" name="Neapolitan Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="75" speed="46" charge_damage="8" body_length="105" is_mountable="true" extra_health="39" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="77" speed="42" charge_damage="8" body_length="105" is_mountable="true" extra_health="39" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2870,9 +2870,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_12_v1_h2" name="Neapolitan Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_12_v2_h2" name="Neapolitan Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="76" speed="46" charge_damage="8" body_length="105" is_mountable="true" extra_health="55" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="78" speed="42" charge_damage="8" body_length="105" is_mountable="true" extra_health="55" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2887,9 +2887,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_12_v1_h3" name="Neapolitan Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_12_v2_h3" name="Neapolitan Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="77" speed="46" charge_damage="8" body_length="105" is_mountable="true" extra_health="70" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="79" speed="42" charge_damage="8" body_length="105" is_mountable="true" extra_health="70" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2904,9 +2904,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_13_v1_h0" name="Hengeron Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_13_v2_h0" name="Hengeron Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="76" speed="46" charge_damage="9" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="78" speed="42" charge_damage="9" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2921,9 +2921,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_13_v1_h1" name="Hengeron Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_13_v2_h1" name="Hengeron Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="76" speed="47" charge_damage="9" body_length="105" is_mountable="true" extra_health="43" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="78" speed="43" charge_damage="9" body_length="105" is_mountable="true" extra_health="43" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2938,9 +2938,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_13_v1_h2" name="Hengeron Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_13_v2_h2" name="Hengeron Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="77" speed="47" charge_damage="9" body_length="105" is_mountable="true" extra_health="58" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="79" speed="43" charge_damage="9" body_length="105" is_mountable="true" extra_health="58" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2955,9 +2955,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_13_v1_h3" name="Hengeron Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_13_v2_h3" name="Hengeron Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="78" speed="47" charge_damage="9" body_length="105" is_mountable="true" extra_health="74" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="80" speed="43" charge_damage="9" body_length="105" is_mountable="true" extra_health="74" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2972,9 +2972,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_14_v1_h0" name="Bucephalus Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_14_v2_h0" name="Bucephalus Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="76" speed="47" charge_damage="9" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="78" speed="43" charge_damage="9" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -2989,9 +2989,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_14_v1_h1" name="Bucephalus Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_14_v2_h1" name="Bucephalus Charger +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="76" speed="48" charge_damage="9" body_length="105" is_mountable="true" extra_health="46" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="78" speed="44" charge_damage="9" body_length="105" is_mountable="true" extra_health="46" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3006,9 +3006,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_14_v1_h2" name="Bucephalus Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_14_v2_h2" name="Bucephalus Charger +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="77" speed="48" charge_damage="9" body_length="105" is_mountable="true" extra_health="62" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="79" speed="44" charge_damage="9" body_length="105" is_mountable="true" extra_health="62" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3023,9 +3023,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_charger_14_v1_h3" name="Bucephalus Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_14_v2_h3" name="Bucephalus Charger +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_105" maneuver="78" speed="48" charge_damage="9" body_length="105" is_mountable="true" extra_health="77" modifier_group="horse">
+      <Horse monster="Monster.horse_105" maneuver="80" speed="44" charge_damage="9" body_length="105" is_mountable="true" extra_health="77" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3040,9 +3040,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_5_v1_h0" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_5_v2_h0" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="62" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="64" speed="40" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3056,9 +3056,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_5_v1_h1" name="Turkoman Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_5_v2_h1" name="Turkoman Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="62" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="64" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3072,9 +3072,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_5_v1_h2" name="Turkoman Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_5_v2_h2" name="Turkoman Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="63" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="11" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="65" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3088,9 +3088,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_5_v1_h3" name="Turkoman Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_5_v2_h3" name="Turkoman Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="64" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="23" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="66" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="23" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3104,9 +3104,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_6_v1_h0" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_6_v2_h0" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="64" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="66" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3120,9 +3120,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_6_v1_h1" name="Menorquín Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_6_v2_h1" name="Menorquín Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="64" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="66" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3136,9 +3136,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_6_v1_h2" name="Menorquín Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_6_v2_h2" name="Menorquín Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="65" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="67" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3152,9 +3152,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_6_v1_h3" name="Menorquín Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_6_v2_h3" name="Menorquín Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="66" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="68" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3168,9 +3168,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_7_v1_h0" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_7_v2_h0" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="66" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="68" speed="42" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3184,9 +3184,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_7_v1_h1" name="Nisean Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_7_v2_h1" name="Nisean Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="66" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="68" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3200,9 +3200,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_7_v1_h2" name="Nisean Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_7_v2_h2" name="Nisean Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="67" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="69" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3216,9 +3216,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_7_v1_h3" name="Nisean Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_7_v2_h3" name="Nisean Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="68" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="70" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3232,9 +3232,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_8_v1_h0" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_8_v2_h0" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="68" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="70" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3248,9 +3248,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_8_v1_h1" name="Thessalian Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_8_v2_h1" name="Thessalian Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="68" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="8" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="70" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3264,9 +3264,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_8_v1_h2" name="Thessalian Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_8_v2_h2" name="Thessalian Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="69" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="21" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="71" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="21" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3280,9 +3280,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_8_v1_h3" name="Thessalian Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_8_v2_h3" name="Thessalian Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="70" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="72" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3296,9 +3296,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_9_v1_h0" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_9_v2_h0" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="70" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="72" speed="44" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3312,9 +3312,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_9_v1_h1" name="Einsiedler Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_9_v2_h1" name="Einsiedler Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="70" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="11" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="72" speed="45" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3328,9 +3328,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_9_v1_h2" name="Einsiedler Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_9_v2_h2" name="Einsiedler Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="71" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="73" speed="45" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3344,9 +3344,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_9_v1_h3" name="Einsiedler Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_9_v2_h3" name="Einsiedler Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="72" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="38" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="74" speed="45" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="38" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3360,9 +3360,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_10_v1_h0" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_10_v2_h0" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="71" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="73" speed="45" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3376,9 +3376,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_10_v1_h1" name="Ahalteke Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_10_v2_h1" name="Ahalteke Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="71" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="73" speed="46" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3392,9 +3392,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_10_v1_h2" name="Ahalteke Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_10_v2_h2" name="Ahalteke Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="72" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="74" speed="46" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3408,9 +3408,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_10_v1_h3" name="Ahalteke Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_10_v2_h3" name="Ahalteke Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="41" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="75" speed="46" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="41" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3424,9 +3424,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_11_v1_h0" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_11_v2_h0" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="72" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="74" speed="45" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3440,9 +3440,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_11_v1_h1" name="Datong Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_11_v2_h1" name="Datong Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="72" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="74" speed="46" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3456,9 +3456,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_11_v1_h2" name="Datong Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_11_v2_h2" name="Datong Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="75" speed="46" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3472,9 +3472,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_11_v1_h3" name="Datong Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_11_v2_h3" name="Datong Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="45" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="46" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="45" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3488,9 +3488,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_12_v1_h0" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_12_v2_h0" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="75" speed="46" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3504,9 +3504,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_12_v1_h1" name="Darashouri Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_12_v2_h1" name="Darashouri Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="73" speed="51" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="20" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="75" speed="47" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3520,9 +3520,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_12_v1_h2" name="Darashouri Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_12_v2_h2" name="Darashouri Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="51" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="47" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3536,9 +3536,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_12_v1_h3" name="Darashouri Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_12_v2_h3" name="Darashouri Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="75" speed="51" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="48" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="77" speed="47" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="48" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3552,9 +3552,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_13_v1_h0" name="Sanfratellano Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_13_v2_h0" name="Sanfratellano Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="51" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="47" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3568,9 +3568,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_13_v1_h1" name="Sanfratellano Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_13_v2_h1" name="Sanfratellano Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="48" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3584,9 +3584,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_13_v1_h2" name="Sanfratellano Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_13_v2_h2" name="Sanfratellano Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="75" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="38" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="77" speed="48" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="38" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3600,9 +3600,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_13_v1_h3" name="Sanfratellano Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_13_v2_h3" name="Sanfratellano Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="76" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="52" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="78" speed="48" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="52" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3616,9 +3616,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_14_v1_h0" name="Muniqi al-Khamsa Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_14_v2_h0" name="Muniqi al-Khamsa Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="48" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3632,9 +3632,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_14_v1_h1" name="Muniqi al-Khamsa Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_14_v2_h1" name="Muniqi al-Khamsa Courser +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="53" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="49" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3648,9 +3648,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_14_v1_h2" name="Muniqi al-Khamsa Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_14_v2_h2" name="Muniqi al-Khamsa Courser +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="75" speed="53" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="41" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="77" speed="49" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="41" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3664,9 +3664,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_courser_14_v1_h3" name="Muniqi al-Khamsa Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_courser_14_v2_h3" name="Muniqi al-Khamsa Courser +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="76" speed="53" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="56" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="78" speed="49" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="56" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3680,9 +3680,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_5_v1_h0" name="Mérengais Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_5_v2_h0" name="Mérengais Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_96" maneuver="62" speed="51" charge_damage="2" body_length="96" is_mountable="true" is_pack_animal="true" extra_health="-71" modifier_group="horse">
+      <Horse monster="Monster.horse_96" maneuver="64" speed="43" charge_damage="2" body_length="96" is_mountable="true" is_pack_animal="true" extra_health="-71" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3696,9 +3696,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_5_v1_h1" name="Mérengais Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_5_v2_h1" name="Mérengais Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_96" maneuver="62" speed="52" charge_damage="2" body_length="96" is_mountable="true" is_pack_animal="true" extra_health="-63" modifier_group="horse">
+      <Horse monster="Monster.horse_96" maneuver="64" speed="44" charge_damage="2" body_length="96" is_mountable="true" is_pack_animal="true" extra_health="-63" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3712,9 +3712,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_5_v1_h2" name="Mérengais Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_5_v2_h2" name="Mérengais Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_96" maneuver="63" speed="52" charge_damage="2" body_length="96" is_mountable="true" is_pack_animal="true" extra_health="-54" modifier_group="horse">
+      <Horse monster="Monster.horse_96" maneuver="65" speed="44" charge_damage="2" body_length="96" is_mountable="true" is_pack_animal="true" extra_health="-54" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3728,9 +3728,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_5_v1_h3" name="Mérengais Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_5_v2_h3" name="Mérengais Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_96" maneuver="64" speed="52" charge_damage="2" body_length="96" is_mountable="true" is_pack_animal="true" extra_health="-45" modifier_group="horse">
+      <Horse monster="Monster.horse_96" maneuver="66" speed="44" charge_damage="2" body_length="96" is_mountable="true" is_pack_animal="true" extra_health="-45" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3744,9 +3744,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_6_v1_h0" name="Galician Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_6_v2_h0" name="Galician Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="64" speed="52" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-68" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="66" speed="44" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-68" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3760,9 +3760,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_6_v1_h1" name="Galician Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_6_v2_h1" name="Galician Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="64" speed="53" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-59" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="66" speed="45" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-59" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3776,9 +3776,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_6_v1_h2" name="Galician Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_6_v2_h2" name="Galician Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="65" speed="53" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-50" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="67" speed="45" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-50" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3792,9 +3792,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_6_v1_h3" name="Galician Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_6_v2_h3" name="Galician Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="66" speed="53" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-41" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="68" speed="45" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-41" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3808,9 +3808,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_7_v1_h0" name="Lichuan Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_7_v2_h0" name="Lichuan Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="66" speed="53" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-65" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="68" speed="45" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-65" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3824,9 +3824,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_7_v1_h1" name="Lichuan Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_7_v2_h1" name="Lichuan Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="66" speed="54" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-56" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="68" speed="46" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-56" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3840,9 +3840,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_7_v1_h2" name="Lichuan Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_7_v2_h2" name="Lichuan Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="67" speed="54" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-47" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="69" speed="46" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-47" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3856,9 +3856,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_7_v1_h3" name="Lichuan Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_7_v2_h3" name="Lichuan Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="68" speed="54" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-38" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="70" speed="46" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-38" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3872,9 +3872,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_8_v1_h0" name="Dongolawi Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_8_v2_h0" name="Dongolawi Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="68" speed="54" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-62" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="70" speed="46" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-62" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3888,9 +3888,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_8_v1_h1" name="Dongolawi Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_8_v2_h1" name="Dongolawi Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="68" speed="55" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-53" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="70" speed="47" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-53" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3904,9 +3904,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_8_v1_h2" name="Dongolawi Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_8_v2_h2" name="Dongolawi Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="69" speed="55" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-44" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="71" speed="47" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-44" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3920,9 +3920,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_8_v1_h3" name="Dongolawi Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_8_v2_h3" name="Dongolawi Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="70" speed="55" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-34" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="72" speed="47" charge_damage="2" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3936,9 +3936,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_9_v1_h0" name="Kyrgyz Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_9_v2_h0" name="Kyrgyz Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="70" speed="55" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-59" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="72" speed="47" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-59" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3952,9 +3952,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_9_v1_h1" name="Kyrgyz Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_9_v2_h1" name="Kyrgyz Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="70" speed="56" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-50" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="72" speed="48" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-50" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3968,9 +3968,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_9_v1_h2" name="Kyrgyz Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_9_v2_h2" name="Kyrgyz Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="71" speed="56" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-40" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="73" speed="48" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-40" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -3984,9 +3984,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_9_v1_h3" name="Kyrgyz Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_9_v2_h3" name="Kyrgyz Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="72" speed="56" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-31" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="74" speed="48" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4000,9 +4000,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_10_v1_h0" name="Maremmano Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_10_v2_h0" name="Maremmano Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="71" speed="56" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-56" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="73" speed="48" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-56" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4016,9 +4016,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_10_v1_h1" name="Maremmano Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_10_v2_h1" name="Maremmano Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="71" speed="57" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-47" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="73" speed="49" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-47" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4032,9 +4032,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_10_v1_h2" name="Maremmano Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_10_v2_h2" name="Maremmano Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="72" speed="57" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-37" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="74" speed="49" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-37" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4048,9 +4048,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_10_v1_h3" name="Maremmano Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_10_v2_h3" name="Maremmano Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="73" speed="57" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-27" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="75" speed="49" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4064,9 +4064,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_11_v1_h0" name="Lipizzana Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_11_v2_h0" name="Lipizzana Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="72" speed="57" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-53" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="74" speed="48" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-53" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4080,9 +4080,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_11_v1_h1" name="Lipizzana Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_11_v2_h1" name="Lipizzana Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="72" speed="58" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-43" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="74" speed="49" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-43" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4096,9 +4096,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_11_v1_h2" name="Lipizzana Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_11_v2_h2" name="Lipizzana Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="73" speed="58" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-33" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="75" speed="49" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-33" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4112,9 +4112,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_11_v1_h3" name="Lipizzana Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_11_v2_h3" name="Lipizzana Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="74" speed="58" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-23" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="76" speed="49" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-23" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4128,9 +4128,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_12_v1_h0" name="Charollais Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_12_v2_h0" name="Charollais Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="73" speed="58" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-50" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="75" speed="49" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-50" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4144,9 +4144,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_12_v1_h1" name="Charollais Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_12_v2_h1" name="Charollais Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="73" speed="59" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-40" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="75" speed="50" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-40" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4160,9 +4160,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_12_v1_h2" name="Charollais Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_12_v2_h2" name="Charollais Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="74" speed="59" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-30" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="76" speed="50" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-30" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4176,9 +4176,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_12_v1_h3" name="Charollais Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_12_v2_h3" name="Charollais Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="75" speed="59" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="77" speed="50" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4192,9 +4192,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_13_v1_h0" name="Senne Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_13_v2_h0" name="Senne Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="74" speed="59" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-47" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="76" speed="50" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-47" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4208,9 +4208,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_13_v1_h1" name="Senne Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_13_v2_h1" name="Senne Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="74" speed="60" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-37" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="76" speed="51" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-37" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4224,9 +4224,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_13_v1_h2" name="Senne Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_13_v2_h2" name="Senne Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="75" speed="60" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-27" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="77" speed="51" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4240,9 +4240,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_13_v1_h3" name="Senne Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_13_v2_h3" name="Senne Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_98" maneuver="76" speed="60" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-16" modifier_group="horse">
+      <Horse monster="Monster.horse_98" maneuver="78" speed="51" charge_damage="3" body_length="98" is_mountable="true" is_pack_animal="true" extra_health="-16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4256,9 +4256,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_15_v1_h0" name="Grani Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_15_v2_h0" name="Grani Saddle Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="60" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-44" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="51" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-44" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4272,9 +4272,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_15_v1_h1" name="Grani Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_15_v2_h1" name="Grani Saddle Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="61" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-34" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="52" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4288,9 +4288,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_15_v1_h2" name="Grani Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_15_v2_h2" name="Grani Saddle Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="75" speed="61" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-23" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="77" speed="52" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-23" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4304,9 +4304,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_15_v1_h3" name="Grani Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_15_v2_h3" name="Grani Saddle Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="76" speed="61" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-13" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="78" speed="52" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4320,9 +4320,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_14_v1_h0" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_14_v2_h0" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="69" speed="68" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-50" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="71" speed="64" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-50" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4336,9 +4336,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_14_v1_h1" name="Shadowfax +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_14_v2_h1" name="Shadowfax +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="69" speed="69" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-40" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="71" speed="65" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-40" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4352,9 +4352,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_14_v1_h2" name="Shadowfax +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_14_v2_h2" name="Shadowfax +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="70" speed="69" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-30" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="72" speed="65" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-30" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4368,9 +4368,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount1_saddlehorse_14_v1_h3" name="Shadowfax +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_saddlehorse_14_v2_h3" name="Shadowfax +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="71" speed="69" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="73" speed="65" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4384,9 +4384,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_5_v1_h0" name="Suffolk Punch Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_5_v2_h0" name="Suffolk Punch Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="72" speed="35" charge_damage="4" body_length="107" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="74" speed="31" charge_damage="4" body_length="107" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4401,9 +4401,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_5_v1_h1" name="Suffolk Punch Draught +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_5_v2_h1" name="Suffolk Punch Draught +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="72" speed="36" charge_damage="4" body_length="107" is_mountable="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="74" speed="32" charge_damage="4" body_length="107" is_mountable="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4418,9 +4418,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_5_v1_h2" name="Suffolk Punch Draught +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_5_v2_h2" name="Suffolk Punch Draught +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="73" speed="36" charge_damage="4" body_length="107" is_mountable="true" extra_health="38" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="75" speed="32" charge_damage="4" body_length="107" is_mountable="true" extra_health="38" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4435,9 +4435,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_5_v1_h3" name="Suffolk Punch Draught +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_5_v2_h3" name="Suffolk Punch Draught +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="74" speed="36" charge_damage="4" body_length="107" is_mountable="true" extra_health="52" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="76" speed="32" charge_damage="4" body_length="107" is_mountable="true" extra_health="52" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4452,9 +4452,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_6_v1_h0" name="Boulonnais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_6_v2_h0" name="Boulonnais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="74" speed="36" charge_damage="5" body_length="107" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="76" speed="32" charge_damage="5" body_length="107" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4469,9 +4469,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_6_v1_h1" name="Boulonnais Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_6_v2_h1" name="Boulonnais Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="74" speed="37" charge_damage="5" body_length="107" is_mountable="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="76" speed="33" charge_damage="5" body_length="107" is_mountable="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4486,9 +4486,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_6_v1_h2" name="Boulonnais Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_6_v2_h2" name="Boulonnais Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="75" speed="37" charge_damage="5" body_length="107" is_mountable="true" extra_health="41" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="77" speed="33" charge_damage="5" body_length="107" is_mountable="true" extra_health="41" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4503,9 +4503,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_6_v1_h3" name="Boulonnais Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_6_v2_h3" name="Boulonnais Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="76" speed="37" charge_damage="5" body_length="107" is_mountable="true" extra_health="56" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="78" speed="33" charge_damage="5" body_length="107" is_mountable="true" extra_health="56" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4520,9 +4520,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_7_v1_h0" name="Galloway Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_7_v2_h0" name="Galloway Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="76" speed="37" charge_damage="6" body_length="107" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="78" speed="33" charge_damage="6" body_length="107" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4537,9 +4537,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_7_v1_h1" name="Galloway Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_7_v2_h1" name="Galloway Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="76" speed="38" charge_damage="6" body_length="107" is_mountable="true" extra_health="30" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="78" speed="34" charge_damage="6" body_length="107" is_mountable="true" extra_health="30" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4554,9 +4554,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_7_v1_h2" name="Galloway Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_7_v2_h2" name="Galloway Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="77" speed="38" charge_damage="6" body_length="107" is_mountable="true" extra_health="45" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="79" speed="34" charge_damage="6" body_length="107" is_mountable="true" extra_health="45" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4571,9 +4571,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_7_v1_h3" name="Galloway Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_7_v2_h3" name="Galloway Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="78" speed="38" charge_damage="6" body_length="107" is_mountable="true" extra_health="59" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="80" speed="34" charge_damage="6" body_length="107" is_mountable="true" extra_health="59" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4588,9 +4588,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_8_v1_h0" name="Poitevin Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_8_v2_h0" name="Poitevin Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="78" speed="38" charge_damage="6" body_length="107" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="80" speed="34" charge_damage="6" body_length="107" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4605,9 +4605,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_8_v1_h1" name="Poitevin Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_8_v2_h1" name="Poitevin Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="78" speed="39" charge_damage="6" body_length="107" is_mountable="true" extra_health="33" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="80" speed="35" charge_damage="6" body_length="107" is_mountable="true" extra_health="33" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4622,9 +4622,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_8_v1_h2" name="Poitevin Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_8_v2_h2" name="Poitevin Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="79" speed="39" charge_damage="6" body_length="107" is_mountable="true" extra_health="48" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="81" speed="35" charge_damage="6" body_length="107" is_mountable="true" extra_health="48" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4639,9 +4639,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_8_v1_h3" name="Poitevin Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_8_v2_h3" name="Poitevin Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="80" speed="39" charge_damage="6" body_length="107" is_mountable="true" extra_health="63" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="82" speed="35" charge_damage="6" body_length="107" is_mountable="true" extra_health="63" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4656,9 +4656,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_9_v1_h0" name="Oberlander Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_9_v2_h0" name="Oberlander Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="80" speed="38" charge_damage="7" body_length="107" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="82" speed="34" charge_damage="7" body_length="107" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4673,9 +4673,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_9_v1_h1" name="Oberlander Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_9_v2_h1" name="Oberlander Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="80" speed="39" charge_damage="7" body_length="107" is_mountable="true" extra_health="36" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="82" speed="35" charge_damage="7" body_length="107" is_mountable="true" extra_health="36" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4690,9 +4690,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_9_v1_h2" name="Oberlander Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_9_v2_h2" name="Oberlander Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="81" speed="39" charge_damage="7" body_length="107" is_mountable="true" extra_health="51" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="83" speed="35" charge_damage="7" body_length="107" is_mountable="true" extra_health="51" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4707,9 +4707,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_9_v1_h3" name="Oberlander Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_9_v2_h3" name="Oberlander Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="82" speed="39" charge_damage="7" body_length="107" is_mountable="true" extra_health="66" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="84" speed="35" charge_damage="7" body_length="107" is_mountable="true" extra_health="66" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4724,9 +4724,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_10_v1_h0" name="Barthais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_10_v2_h0" name="Barthais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="81" speed="39" charge_damage="7" body_length="107" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="83" speed="35" charge_damage="7" body_length="107" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4741,9 +4741,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_10_v1_h1" name="Barthais Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_10_v2_h1" name="Barthais Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="81" speed="40" charge_damage="7" body_length="107" is_mountable="true" extra_health="39" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="83" speed="36" charge_damage="7" body_length="107" is_mountable="true" extra_health="39" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4758,9 +4758,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_10_v1_h2" name="Barthais Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_10_v2_h2" name="Barthais Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="82" speed="40" charge_damage="7" body_length="107" is_mountable="true" extra_health="55" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="84" speed="36" charge_damage="7" body_length="107" is_mountable="true" extra_health="55" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4775,9 +4775,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_10_v1_h3" name="Barthais Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_10_v2_h3" name="Barthais Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="83" speed="40" charge_damage="7" body_length="107" is_mountable="true" extra_health="70" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="85" speed="36" charge_damage="7" body_length="107" is_mountable="true" extra_health="70" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4792,9 +4792,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_11_v1_h0" name="Brabant Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_11_v2_h0" name="Brabant Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="82" speed="39" charge_damage="8" body_length="107" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="84" speed="35" charge_damage="8" body_length="107" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4809,9 +4809,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_11_v1_h1" name="Brabant Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_11_v2_h1" name="Brabant Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="82" speed="40" charge_damage="8" body_length="107" is_mountable="true" extra_health="43" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="84" speed="36" charge_damage="8" body_length="107" is_mountable="true" extra_health="43" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4826,9 +4826,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_11_v1_h2" name="Brabant Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_11_v2_h2" name="Brabant Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="83" speed="40" charge_damage="8" body_length="107" is_mountable="true" extra_health="58" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="85" speed="36" charge_damage="8" body_length="107" is_mountable="true" extra_health="58" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4843,9 +4843,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_11_v1_h3" name="Brabant Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_11_v2_h3" name="Brabant Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="84" speed="40" charge_damage="8" body_length="107" is_mountable="true" extra_health="74" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="86" speed="36" charge_damage="8" body_length="107" is_mountable="true" extra_health="74" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4860,9 +4860,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_12_v1_h0" name="Comtois Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_12_v2_h0" name="Comtois Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="83" speed="40" charge_damage="8" body_length="107" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="85" speed="36" charge_damage="8" body_length="107" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4877,9 +4877,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_12_v1_h1" name="Comtois Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_12_v2_h1" name="Comtois Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="83" speed="41" charge_damage="8" body_length="107" is_mountable="true" extra_health="46" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="85" speed="37" charge_damage="8" body_length="107" is_mountable="true" extra_health="46" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4894,9 +4894,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_12_v1_h2" name="Comtois Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_12_v2_h2" name="Comtois Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="84" speed="41" charge_damage="8" body_length="107" is_mountable="true" extra_health="62" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="86" speed="37" charge_damage="8" body_length="107" is_mountable="true" extra_health="62" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4911,9 +4911,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_12_v1_h3" name="Comtois Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_12_v2_h3" name="Comtois Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="85" speed="41" charge_damage="8" body_length="107" is_mountable="true" extra_health="77" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="87" speed="37" charge_damage="8" body_length="107" is_mountable="true" extra_health="77" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4928,9 +4928,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_13_v1_h0" name="English Black Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_13_v2_h0" name="English Black Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="84" speed="40" charge_damage="8" body_length="107" is_mountable="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="86" speed="36" charge_damage="8" body_length="107" is_mountable="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4945,9 +4945,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_13_v1_h1" name="English Black Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_13_v2_h1" name="English Black Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="84" speed="41" charge_damage="8" body_length="107" is_mountable="true" extra_health="49" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="86" speed="37" charge_damage="8" body_length="107" is_mountable="true" extra_health="49" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4962,9 +4962,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_13_v1_h2" name="English Black Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_13_v2_h2" name="English Black Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="85" speed="41" charge_damage="8" body_length="107" is_mountable="true" extra_health="65" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="87" speed="37" charge_damage="8" body_length="107" is_mountable="true" extra_health="65" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4979,9 +4979,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_13_v1_h3" name="English Black Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_13_v2_h3" name="English Black Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="86" speed="41" charge_damage="8" body_length="107" is_mountable="true" extra_health="81" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="88" speed="37" charge_damage="8" body_length="107" is_mountable="true" extra_health="81" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -4996,9 +4996,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_14_v1_h0" name="Percheron Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_14_v2_h0" name="Percheron Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="84" speed="41" charge_damage="9" body_length="107" is_mountable="true" extra_health="37" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="86" speed="37" charge_damage="9" body_length="107" is_mountable="true" extra_health="37" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5013,9 +5013,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_14_v1_h1" name="Percheron Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_14_v2_h1" name="Percheron Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="84" speed="42" charge_damage="9" body_length="107" is_mountable="true" extra_health="52" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="86" speed="38" charge_damage="9" body_length="107" is_mountable="true" extra_health="52" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5030,9 +5030,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_14_v1_h2" name="Percheron Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_14_v2_h2" name="Percheron Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="85" speed="42" charge_damage="9" body_length="107" is_mountable="true" extra_health="68" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="87" speed="38" charge_damage="9" body_length="107" is_mountable="true" extra_health="68" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5047,9 +5047,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_14_v1_h3" name="Percheron Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_14_v2_h3" name="Percheron Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="86" speed="42" charge_damage="9" body_length="107" is_mountable="true" extra_health="84" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="88" speed="38" charge_damage="9" body_length="107" is_mountable="true" extra_health="84" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5064,9 +5064,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_15_v1_h0" name="Lionheart Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_15_v2_h0" name="Lionheart Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="84" speed="42" charge_damage="9" body_length="107" is_mountable="true" extra_health="40" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="86" speed="38" charge_damage="9" body_length="107" is_mountable="true" extra_health="40" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5081,9 +5081,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_15_v1_h1" name="Lionheart Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_15_v2_h1" name="Lionheart Great Horse +1" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="84" speed="43" charge_damage="9" body_length="107" is_mountable="true" extra_health="55" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="86" speed="39" charge_damage="9" body_length="107" is_mountable="true" extra_health="55" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5098,9 +5098,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_15_v1_h2" name="Lionheart Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_15_v2_h2" name="Lionheart Great Horse +2" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="85" speed="43" charge_damage="9" body_length="107" is_mountable="true" extra_health="72" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="87" speed="39" charge_damage="9" body_length="107" is_mountable="true" extra_health="72" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5115,9 +5115,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_greathorse_15_v1_h3" name="Lionheart Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_15_v2_h3" name="Lionheart Great Horse +3" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_107" maneuver="86" speed="43" charge_damage="9" body_length="107" is_mountable="true" extra_health="88" modifier_group="horse">
+      <Horse monster="Monster.horse_107" maneuver="88" speed="39" charge_damage="9" body_length="107" is_mountable="true" extra_health="88" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5132,9 +5132,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_2_v1_h0" name="Sumpter Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_2_v2_h0" name="Sumpter Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="60" speed="34" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="62" speed="30" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5148,9 +5148,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_2_v1_h1" name="Sumpter Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_2_v2_h1" name="Sumpter Horse +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="60" speed="35" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="62" speed="31" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5164,9 +5164,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_2_v1_h2" name="Sumpter Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_2_v2_h2" name="Sumpter Horse +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="61" speed="35" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="63" speed="31" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5180,9 +5180,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_2_v1_h3" name="Sumpter Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_2_v2_h3" name="Sumpter Horse +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="62" speed="35" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="41" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="64" speed="31" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="41" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5196,9 +5196,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_3_v1_h0" name="Raymond Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_3_v2_h0" name="Raymond Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="62" speed="38" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="64" speed="34" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5212,9 +5212,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_3_v1_h1" name="Raymond Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_3_v2_h1" name="Raymond Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="62" speed="39" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="64" speed="35" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5228,9 +5228,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_3_v1_h2" name="Raymond Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_3_v2_h2" name="Raymond Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="63" speed="39" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="65" speed="35" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5244,9 +5244,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_3_v1_h3" name="Raymond Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_3_v2_h3" name="Raymond Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="64" speed="39" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="66" speed="35" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5260,9 +5260,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_4_v1_h0" name="Fell Pony" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_4_v2_h0" name="Fell Pony" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="64" speed="40" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="66" speed="36" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5276,9 +5276,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_4_v1_h1" name="Fell Pony +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_4_v2_h1" name="Fell Pony +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="64" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="66" speed="37" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5292,9 +5292,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_4_v1_h2" name="Fell Pony +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_4_v2_h2" name="Fell Pony +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="65" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="67" speed="37" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5308,9 +5308,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_4_v1_h3" name="Fell Pony +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_4_v2_h3" name="Fell Pony +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="66" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="68" speed="37" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5324,9 +5324,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_5_v1_h0" name="Welsh Cob" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.battania" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_5_v2_h0" name="Welsh Cob" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.battania" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="66" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="68" speed="37" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5340,9 +5340,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_5_v1_h1" name="Welsh Cob +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.battania" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_5_v2_h1" name="Welsh Cob +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.battania" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="66" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="68" speed="38" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5356,9 +5356,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_5_v1_h2" name="Welsh Cob +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.battania" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_5_v2_h2" name="Welsh Cob +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.battania" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="67" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="69" speed="38" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5372,9 +5372,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_5_v1_h3" name="Welsh Cob +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.battania" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_5_v2_h3" name="Welsh Cob +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.battania" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="68" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="20" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="70" speed="38" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5388,9 +5388,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_6_v1_h0" name="Sanhe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_6_v2_h0" name="Sanhe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="68" speed="42" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="70" speed="38" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5404,9 +5404,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_6_v1_h1" name="Sanhe Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_6_v2_h1" name="Sanhe Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="68" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="70" speed="39" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5420,9 +5420,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_6_v1_h2" name="Sanhe Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_6_v2_h2" name="Sanhe Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="69" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="11" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="71" speed="39" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5436,9 +5436,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_6_v1_h3" name="Sanhe Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_6_v2_h3" name="Sanhe Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="70" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="23" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="72" speed="39" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="23" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5452,9 +5452,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_7_v1_h0" name="Megrelakaya Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_7_v2_h0" name="Megrelakaya Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="70" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="72" speed="39" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5468,9 +5468,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_7_v1_h1" name="Megrelakaya Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_7_v2_h1" name="Megrelakaya Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="70" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="72" speed="40" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5484,9 +5484,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_7_v1_h2" name="Megrelakaya Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_7_v2_h2" name="Megrelakaya Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="71" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="73" speed="40" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5500,9 +5500,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_7_v1_h3" name="Megrelakaya Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_7_v2_h3" name="Megrelakaya Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.empire" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="72" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="74" speed="40" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5516,9 +5516,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_8_v1_h0" name="East Anglis Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_8_v2_h0" name="East Anglis Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="72" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="74" speed="40" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5532,9 +5532,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_8_v1_h1" name="East Anglis Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_8_v2_h1" name="East Anglis Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="72" speed="45" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="74" speed="41" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5548,9 +5548,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_8_v1_h2" name="East Anglis Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_8_v2_h2" name="East Anglis Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="73" speed="45" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="75" speed="41" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5564,9 +5564,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_8_v1_h3" name="East Anglis Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_8_v2_h3" name="East Anglis Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="45" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="41" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5580,9 +5580,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_9_v1_h0" name="Anadolu Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_9_v2_h0" name="Anadolu Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="45" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="41" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5596,9 +5596,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_9_v1_h1" name="Anadolu Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_9_v2_h1" name="Anadolu Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="74" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="8" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="76" speed="42" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5612,9 +5612,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_9_v1_h2" name="Anadolu Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_9_v2_h2" name="Anadolu Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="75" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="21" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="77" speed="42" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="21" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5628,9 +5628,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_9_v1_h3" name="Anadolu Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_9_v2_h3" name="Anadolu Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="76" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="78" speed="42" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5644,9 +5644,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_10_v1_h0" name="Black Forest Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_10_v2_h0" name="Black Forest Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="75" speed="45" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="77" speed="41" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5660,9 +5660,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_10_v1_h1" name="Black Forest Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_10_v2_h1" name="Black Forest Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="75" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="11" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="77" speed="42" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5676,9 +5676,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_10_v1_h2" name="Black Forest Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_10_v2_h2" name="Black Forest Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="76" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="78" speed="42" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5692,9 +5692,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_10_v1_h3" name="Black Forest Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_10_v2_h3" name="Black Forest Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="77" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="38" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="79" speed="42" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="38" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5708,9 +5708,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_11_v1_h0" name="Bidet Breton Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_11_v2_h0" name="Bidet Breton Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="76" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="78" speed="42" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5724,9 +5724,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_11_v1_h1" name="Bidet Breton Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_11_v2_h1" name="Bidet Breton Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="76" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="78" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5740,9 +5740,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_11_v1_h2" name="Bidet Breton Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_11_v2_h2" name="Bidet Breton Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="77" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="79" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5756,9 +5756,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_11_v1_h3" name="Bidet Breton Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_11_v2_h3" name="Bidet Breton Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.vlandia" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="78" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="41" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="80" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="41" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5772,9 +5772,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_12_v1_h0" name="Dzhabe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_12_v2_h0" name="Dzhabe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="77" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="79" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5788,9 +5788,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_12_v1_h1" name="Dzhabe Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_12_v2_h1" name="Dzhabe Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="77" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="79" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5804,9 +5804,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_12_v1_h2" name="Dzhabe Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_12_v2_h2" name="Dzhabe Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="78" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="80" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5820,9 +5820,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_12_v1_h3" name="Dzhabe Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_12_v2_h3" name="Dzhabe Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="79" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="45" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="81" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="45" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5836,9 +5836,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_13_v1_h0" name="Karachay Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_13_v2_h0" name="Karachay Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="78" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="80" speed="43" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5852,9 +5852,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_13_v1_h1" name="Karachay Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_13_v2_h1" name="Karachay Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="78" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="20" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="80" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5868,9 +5868,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_13_v1_h2" name="Karachay Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_13_v2_h2" name="Karachay Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="79" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="81" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5884,9 +5884,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_13_v1_h3" name="Karachay Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_13_v2_h3" name="Karachay Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.khuzait" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="80" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="48" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="82" speed="44" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="48" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5900,9 +5900,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_14_v1_h0" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_14_v2_h0" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="78" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="80" speed="44" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5916,9 +5916,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_14_v1_h1" name="Unmol Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_14_v2_h1" name="Unmol Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="78" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="80" speed="45" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5932,9 +5932,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_14_v1_h2" name="Unmol Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_14_v2_h2" name="Unmol Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="79" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="38" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="81" speed="45" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="38" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5948,9 +5948,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_14_v1_h3" name="Unmol Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_14_v2_h3" name="Unmol Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" culture="Culture.aserai" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="80" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="52" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="82" speed="45" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="52" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5964,9 +5964,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_15_v1_h0" name="Kehilan al-Khamsa Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_15_v2_h0" name="Kehilan al-Khamsa Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="78" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="80" speed="45" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5980,9 +5980,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_15_v1_h1" name="Kehilan al-Khamsa Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_15_v2_h1" name="Kehilan al-Khamsa Rouncey +1" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="78" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="80" speed="46" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -5996,9 +5996,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_15_v1_h2" name="Kehilan al-Khamsa Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_15_v2_h2" name="Kehilan al-Khamsa Rouncey +2" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="79" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="41" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="81" speed="46" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="41" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -6012,9 +6012,9 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_mount_rouncey_15_v1_h3" name="Kehilan al-Khamsa Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_15_v2_h3" name="Kehilan al-Khamsa Rouncey +3" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse_100" maneuver="80" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="56" modifier_group="horse">
+      <Horse monster="Monster.horse_100" maneuver="82" speed="46" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="56" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -6028,2881 +6028,2881 @@
       </Horse>
     </ItemComponent>
   </Item>
-  <Item id="crpg_caparison_template_jerusalem_v2_h0" name="Caparison, Jerusalem (White)" mesh="caparison_template_jerusalem" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_jerusalem_v3_h0" name="Caparison, Jerusalem (White)" mesh="caparison_template_jerusalem" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_jerusalem_v2_h1" name="Caparison, Jerusalem (White) +1" mesh="caparison_template_jerusalem" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_jerusalem_v3_h1" name="Caparison, Jerusalem (White) +1" mesh="caparison_template_jerusalem" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_jerusalem_v2_h2" name="Caparison, Jerusalem (White) +2" mesh="caparison_template_jerusalem" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_jerusalem_v3_h2" name="Caparison, Jerusalem (White) +2" mesh="caparison_template_jerusalem" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_jerusalem_v2_h3" name="Caparison, Jerusalem (White) +3" mesh="caparison_template_jerusalem" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_jerusalem_v3_h3" name="Caparison, Jerusalem (White) +3" mesh="caparison_template_jerusalem" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_jerusalem_teal_v2_h0" name="Caparison, Jerusalem (Teal)" mesh="caparison_template_jerusalem_teal" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_jerusalem_teal_v3_h0" name="Caparison, Jerusalem (Teal)" mesh="caparison_template_jerusalem_teal" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_jerusalem_teal_v2_h1" name="Caparison, Jerusalem (Teal) +1" mesh="caparison_template_jerusalem_teal" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_jerusalem_teal_v3_h1" name="Caparison, Jerusalem (Teal) +1" mesh="caparison_template_jerusalem_teal" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_jerusalem_teal_v2_h2" name="Caparison, Jerusalem (Teal) +2" mesh="caparison_template_jerusalem_teal" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_jerusalem_teal_v3_h2" name="Caparison, Jerusalem (Teal) +2" mesh="caparison_template_jerusalem_teal" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_jerusalem_teal_v2_h3" name="Caparison, Jerusalem (Teal) +3" mesh="caparison_template_jerusalem_teal" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_jerusalem_teal_v3_h3" name="Caparison, Jerusalem (Teal) +3" mesh="caparison_template_jerusalem_teal" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_brabant_v2_h0" name="Caparison, Brabant" mesh="caparison_template_brabant" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_brabant_v3_h0" name="Caparison, Brabant" mesh="caparison_template_brabant" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_brabant_v2_h1" name="Caparison, Brabant +1" mesh="caparison_template_brabant" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_brabant_v3_h1" name="Caparison, Brabant +1" mesh="caparison_template_brabant" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_brabant_v2_h2" name="Caparison, Brabant +2" mesh="caparison_template_brabant" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_brabant_v3_h2" name="Caparison, Brabant +2" mesh="caparison_template_brabant" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_brabant_v2_h3" name="Caparison, Brabant +3" mesh="caparison_template_brabant" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_brabant_v3_h3" name="Caparison, Brabant +3" mesh="caparison_template_brabant" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_teutonic_v2_h0" name="Caparison, Teutonic" mesh="caparison_template_teutonic" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_teutonic_v3_h0" name="Caparison, Teutonic" mesh="caparison_template_teutonic" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_teutonic_v2_h1" name="Caparison, Teutonic +1" mesh="caparison_template_teutonic" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_teutonic_v3_h1" name="Caparison, Teutonic +1" mesh="caparison_template_teutonic" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_teutonic_v2_h2" name="Caparison, Teutonic +2" mesh="caparison_template_teutonic" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_teutonic_v3_h2" name="Caparison, Teutonic +2" mesh="caparison_template_teutonic" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_teutonic_v2_h3" name="Caparison, Teutonic +3" mesh="caparison_template_teutonic" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_teutonic_v3_h3" name="Caparison, Teutonic +3" mesh="caparison_template_teutonic" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_teutonic2_v2_h0" name="Caparison, Teutonic" mesh="caparison_template_teutonic2" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_teutonic2_v3_h0" name="Caparison, Teutonic" mesh="caparison_template_teutonic2" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_teutonic2_v2_h1" name="Caparison, Teutonic +1" mesh="caparison_template_teutonic2" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_teutonic2_v3_h1" name="Caparison, Teutonic +1" mesh="caparison_template_teutonic2" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_teutonic2_v2_h2" name="Caparison, Teutonic +2" mesh="caparison_template_teutonic2" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_teutonic2_v3_h2" name="Caparison, Teutonic +2" mesh="caparison_template_teutonic2" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_teutonic2_v2_h3" name="Caparison, Teutonic +3" mesh="caparison_template_teutonic2" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_teutonic2_v3_h3" name="Caparison, Teutonic +3" mesh="caparison_template_teutonic2" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_bavaria_v2_h0" name="Caparison, Bavaria" mesh="caparison_template_bavaria" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_bavaria_v3_h0" name="Caparison, Bavaria" mesh="caparison_template_bavaria" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_bavaria_v2_h1" name="Caparison, Bavaria +1" mesh="caparison_template_bavaria" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_bavaria_v3_h1" name="Caparison, Bavaria +1" mesh="caparison_template_bavaria" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_bavaria_v2_h2" name="Caparison, Bavaria +2" mesh="caparison_template_bavaria" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_bavaria_v3_h2" name="Caparison, Bavaria +2" mesh="caparison_template_bavaria" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_bavaria_v2_h3" name="Caparison, Bavaria +3" mesh="caparison_template_bavaria" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_bavaria_v3_h3" name="Caparison, Bavaria +3" mesh="caparison_template_bavaria" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_brienne_v2_h0" name="Caparison, Brienne" mesh="caparison_template_brienne" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_brienne_v3_h0" name="Caparison, Brienne" mesh="caparison_template_brienne" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_brienne_v2_h1" name="Caparison, Brienne +1" mesh="caparison_template_brienne" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_brienne_v3_h1" name="Caparison, Brienne +1" mesh="caparison_template_brienne" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_brienne_v2_h2" name="Caparison, Brienne +2" mesh="caparison_template_brienne" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_brienne_v3_h2" name="Caparison, Brienne +2" mesh="caparison_template_brienne" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_brienne_v2_h3" name="Caparison, Brienne +3" mesh="caparison_template_brienne" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_brienne_v3_h3" name="Caparison, Brienne +3" mesh="caparison_template_brienne" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_champagne_v2_h0" name="Caparison, Champagne" mesh="caparison_template_champagne" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_champagne_v3_h0" name="Caparison, Champagne" mesh="caparison_template_champagne" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_champagne_v2_h1" name="Caparison, Champagne +1" mesh="caparison_template_champagne" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_champagne_v3_h1" name="Caparison, Champagne +1" mesh="caparison_template_champagne" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_champagne_v2_h2" name="Caparison, Champagne +2" mesh="caparison_template_champagne" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_champagne_v3_h2" name="Caparison, Champagne +2" mesh="caparison_template_champagne" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_template_champagne_v2_h3" name="Caparison, Champagne +3" mesh="caparison_template_champagne" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_template_champagne_v3_h3" name="Caparison, Champagne +3" mesh="caparison_template_champagne" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_1_v2_h0" name="Armoured Caparison, Checkered (Teamcolor)" mesh="caparison_1" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_1_v3_h0" name="Armoured Caparison, Checkered (Teamcolor)" mesh="caparison_1" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_1_v2_h1" name="Armoured Caparison, Checkered (Teamcolor) +1" mesh="caparison_1" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_1_v3_h1" name="Armoured Caparison, Checkered (Teamcolor) +1" mesh="caparison_1" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_1_v2_h2" name="Armoured Caparison, Checkered (Teamcolor) +2" mesh="caparison_1" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_1_v3_h2" name="Armoured Caparison, Checkered (Teamcolor) +2" mesh="caparison_1" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_caparison_1_v2_h3" name="Armoured Caparison, Checkered (Teamcolor) +3" mesh="caparison_1" weight="35" appearance="10" Type="HorseHarness">
+  <Item id="crpg_caparison_1_v3_h3" name="Armoured Caparison, Checkered (Teamcolor) +3" mesh="caparison_1" weight="35" appearance="10" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_whussar_horsearmor_v1_h0" name="Decorated Plate Barding" mesh="whussar_horsearmor_1" weight="38" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_whussar_horsearmor_v2_h0" name="Decorated Plate Barding" mesh="whussar_horsearmor_1" weight="38" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="none" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_whussar_horsearmor_v1_h1" name="Decorated Plate Barding +1" mesh="whussar_horsearmor_1" weight="38" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_whussar_horsearmor_v2_h1" name="Decorated Plate Barding +1" mesh="whussar_horsearmor_1" weight="38" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="none" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_whussar_horsearmor_v1_h2" name="Decorated Plate Barding +2" mesh="whussar_horsearmor_1" weight="38" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_whussar_horsearmor_v2_h2" name="Decorated Plate Barding +2" mesh="whussar_horsearmor_1" weight="38" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="none" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_whussar_horsearmor_v1_h3" name="Decorated Plate Barding +3" mesh="whussar_horsearmor_1" weight="38" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_whussar_horsearmor_v2_h3" name="Decorated Plate Barding +3" mesh="whussar_horsearmor_1" weight="38" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="47" mane_cover_type="none" family_type="1" modifier_group="chain" reins_mesh="horse_harness_e_rein" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_a_v1_h0" name="{=Telford}Southern Brass Half Scale Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_a" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_a_v2_h0" name="{=Telford}Southern Brass Half Scale Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_a" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_a_v1_h1" name="{=Telford}Southern Brass Half Scale Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_a" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_a_v2_h1" name="{=Telford}Southern Brass Half Scale Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_a" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_a_v1_h2" name="{=Telford}Southern Brass Half Scale Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_a" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_a_v2_h2" name="{=Telford}Southern Brass Half Scale Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_a" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_a_v1_h3" name="{=Telford}Southern Brass Half Scale Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_a" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_a_v2_h3" name="{=Telford}Southern Brass Half Scale Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_a" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_b_v1_h0" name="{=Telford}Southern Steel Half Scale Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_b" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_b_v2_h0" name="{=Telford}Southern Steel Half Scale Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_b" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_b_v1_h1" name="{=Telford}Southern Steel Half Scale Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_b" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_b_v2_h1" name="{=Telford}Southern Steel Half Scale Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_b" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_b_v1_h2" name="{=Telford}Southern Steel Half Scale Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_b" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_b_v2_h2" name="{=Telford}Southern Steel Half Scale Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_b" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_b_v1_h3" name="{=Telford}Southern Steel Half Scale Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_b" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_b_v2_h3" name="{=Telford}Southern Steel Half Scale Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_b" culture="Culture.aserai" weight="32" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_c_v1_h0" name="{=Telford}Southern Brass Scale Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_c" culture="Culture.aserai" weight="36" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_c_v2_h0" name="{=Telford}Southern Brass Scale Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_c" culture="Culture.aserai" weight="36" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_c_v1_h1" name="{=Telford}Southern Brass Scale Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_c" culture="Culture.aserai" weight="36" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_c_v2_h1" name="{=Telford}Southern Brass Scale Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_c" culture="Culture.aserai" weight="36" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_c_v1_h2" name="{=Telford}Southern Brass Scale Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_c" culture="Culture.aserai" weight="36" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_c_v2_h2" name="{=Telford}Southern Brass Scale Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_c" culture="Culture.aserai" weight="36" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_c_v1_h3" name="{=Telford}Southern Brass Scale Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_c" culture="Culture.aserai" weight="36" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_c_v2_h3" name="{=Telford}Southern Brass Scale Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_c" culture="Culture.aserai" weight="36" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_d_v1_h0" name="{=Telford}Southern Steel Scale Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_d" culture="Culture.aserai" weight="40" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_d_v2_h0" name="{=Telford}Southern Steel Scale Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_d" culture="Culture.aserai" weight="40" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="40" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_d_v1_h1" name="{=Telford}Southern Steel Scale Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_d" culture="Culture.aserai" weight="40" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_d_v2_h1" name="{=Telford}Southern Steel Scale Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_d" culture="Culture.aserai" weight="40" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="43" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_d_v1_h2" name="{=Telford}Southern Steel Scale Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_d" culture="Culture.aserai" weight="40" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_d_v2_h2" name="{=Telford}Southern Steel Scale Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_d" culture="Culture.aserai" weight="40" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_d_v1_h3" name="{=Telford}Southern Steel Scale Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_d" culture="Culture.aserai" weight="40" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_d_v2_h3" name="{=Telford}Southern Steel Scale Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_d" culture="Culture.aserai" weight="40" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_e_v1_h0" name="{=Telford}Southern Half Studded Leather Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_e" culture="Culture.aserai" weight="24" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_e_v2_h0" name="{=Telford}Southern Half Studded Leather Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_e" culture="Culture.aserai" weight="24" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="all" family_type="2" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_e_v1_h1" name="{=Telford}Southern Half Studded Leather Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_e" culture="Culture.aserai" weight="24" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_e_v2_h1" name="{=Telford}Southern Half Studded Leather Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_e" culture="Culture.aserai" weight="24" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="27" mane_cover_type="all" family_type="2" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_e_v1_h2" name="{=Telford}Southern Half Studded Leather Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_e" culture="Culture.aserai" weight="24" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_e_v2_h2" name="{=Telford}Southern Half Studded Leather Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_e" culture="Culture.aserai" weight="24" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" family_type="2" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_e_v1_h3" name="{=Telford}Southern Half Studded Leather Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_e" culture="Culture.aserai" weight="24" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_e_v2_h3" name="{=Telford}Southern Half Studded Leather Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_e" culture="Culture.aserai" weight="24" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" family_type="2" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_f_v1_h0" name="{=Telford}Southern Studded Leather Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_f" culture="Culture.aserai" weight="28" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_f_v2_h0" name="{=Telford}Southern Studded Leather Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_f" culture="Culture.aserai" weight="28" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="28" mane_cover_type="all" family_type="2" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_f_v1_h1" name="{=Telford}Southern Studded Leather Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_f" culture="Culture.aserai" weight="28" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_f_v2_h1" name="{=Telford}Southern Studded Leather Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_f" culture="Culture.aserai" weight="28" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="31" mane_cover_type="all" family_type="2" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_f_v1_h2" name="{=Telford}Southern Studded Leather Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_f" culture="Culture.aserai" weight="28" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_f_v2_h2" name="{=Telford}Southern Studded Leather Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_f" culture="Culture.aserai" weight="28" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" family_type="2" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_f_v1_h3" name="{=Telford}Southern Studded Leather Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_f" culture="Culture.aserai" weight="28" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_f_v2_h3" name="{=Telford}Southern Studded Leather Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_f" culture="Culture.aserai" weight="28" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="37" mane_cover_type="all" family_type="2" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_g_v1_h0" name="{=Telford}Southern Half Padded Leather Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_g" culture="Culture.aserai" weight="16" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_g_v2_h0" name="{=Telford}Southern Half Padded Leather Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_g" culture="Culture.aserai" weight="16" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="16" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_g_v1_h1" name="{=Telford}Southern Half Padded Leather Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_g" culture="Culture.aserai" weight="16" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_g_v2_h1" name="{=Telford}Southern Half Padded Leather Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_g" culture="Culture.aserai" weight="16" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="19" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_g_v1_h2" name="{=Telford}Southern Half Padded Leather Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_g" culture="Culture.aserai" weight="16" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_g_v2_h2" name="{=Telford}Southern Half Padded Leather Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_g" culture="Culture.aserai" weight="16" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="22" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_g_v1_h3" name="{=Telford}Southern Half Padded Leather Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_g" culture="Culture.aserai" weight="16" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_g_v2_h3" name="{=Telford}Southern Half Padded Leather Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_g" culture="Culture.aserai" weight="16" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="25" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_h_v1_h0" name="{=Telford}Southern Padded Leather Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_h" culture="Culture.aserai" weight="20" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_h_v2_h0" name="{=Telford}Southern Padded Leather Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_h" culture="Culture.aserai" weight="20" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_h_v1_h1" name="{=Telford}Southern Padded Leather Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_h" culture="Culture.aserai" weight="20" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_h_v2_h1" name="{=Telford}Southern Padded Leather Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_h" culture="Culture.aserai" weight="20" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_h_v1_h2" name="{=Telford}Southern Padded Leather Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_h" culture="Culture.aserai" weight="20" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_h_v2_h2" name="{=Telford}Southern Padded Leather Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_h" culture="Culture.aserai" weight="20" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="26" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_h_v1_h3" name="{=Telford}Southern Padded Leather Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_h" culture="Culture.aserai" weight="20" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_h_v2_h3" name="{=Telford}Southern Padded Leather Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_h" culture="Culture.aserai" weight="20" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="29" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_i_v1_h0" name="{=Telford}Southern Half Wicker Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_i" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_i_v2_h0" name="{=Telford}Southern Half Wicker Dromedary Barding" is_merchandise="true" mesh="tv_camel_scale_armor_i" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="6" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_i_v1_h1" name="{=Telford}Southern Half Wicker Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_i" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_i_v2_h1" name="{=Telford}Southern Half Wicker Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_scale_armor_i" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_i_v1_h2" name="{=Telford}Southern Half Wicker Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_i" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_i_v2_h2" name="{=Telford}Southern Half Wicker Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_scale_armor_i" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_i_v1_h3" name="{=Telford}Southern Half Wicker Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_i" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_i_v2_h3" name="{=Telford}Southern Half Wicker Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_scale_armor_i" culture="Culture.aserai" weight="6" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_j_v1_h0" name="{=Telford}Southern Wicker Dromedary Barding" is_merchandise="true" mesh="tv_camel_Scale_armor_j" culture="Culture.aserai" weight="12" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_j_v2_h0" name="{=Telford}Southern Wicker Dromedary Barding" is_merchandise="true" mesh="tv_camel_Scale_armor_j" culture="Culture.aserai" weight="12" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_j_v1_h1" name="{=Telford}Southern Wicker Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_Scale_armor_j" culture="Culture.aserai" weight="12" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_j_v2_h1" name="{=Telford}Southern Wicker Dromedary Barding +1" is_merchandise="true" mesh="tv_camel_Scale_armor_j" culture="Culture.aserai" weight="12" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_j_v1_h2" name="{=Telford}Southern Wicker Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_Scale_armor_j" culture="Culture.aserai" weight="12" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_j_v2_h2" name="{=Telford}Southern Wicker Dromedary Barding +2" is_merchandise="true" mesh="tv_camel_Scale_armor_j" culture="Culture.aserai" weight="12" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_camelarmor_j_v1_h3" name="{=Telford}Southern Wicker Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_Scale_armor_j" culture="Culture.aserai" weight="12" appearance="1" Type="HorseHarness">
+  <Item id="crpg_tv_camelarmor_j_v2_h3" name="{=Telford}Southern Wicker Dromedary Barding +3" is_merchandise="true" mesh="tv_camel_Scale_armor_j" culture="Culture.aserai" weight="12" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="all" family_type="2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_a_v1_h0" name="{=osa_ar_horse_armor_a}Imperial Decorated Half Mail Barding, Red" mesh="AR_horse_armor_a" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_a_v2_h0" name="{=osa_ar_horse_armor_a}Imperial Decorated Half Mail Barding, Red" mesh="AR_horse_armor_a" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_imperial_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_a_v1_h1" name="{=osa_ar_horse_armor_a}Imperial Decorated Half Mail Barding, Red +1" mesh="AR_horse_armor_a" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_a_v2_h1" name="{=osa_ar_horse_armor_a}Imperial Decorated Half Mail Barding, Red +1" mesh="AR_horse_armor_a" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_imperial_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_a_v1_h2" name="{=osa_ar_horse_armor_a}Imperial Decorated Half Mail Barding, Red +2" mesh="AR_horse_armor_a" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_a_v2_h2" name="{=osa_ar_horse_armor_a}Imperial Decorated Half Mail Barding, Red +2" mesh="AR_horse_armor_a" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_imperial_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_a_v1_h3" name="{=osa_ar_horse_armor_a}Imperial Decorated Half Mail Barding, Red +3" mesh="AR_horse_armor_a" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_a_v2_h3" name="{=osa_ar_horse_armor_a}Imperial Decorated Half Mail Barding, Red +3" mesh="AR_horse_armor_a" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_imperial_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_a2_v1_h0" name="{=osa_ar_horse_armor_a2}Imperial Decorated Half Mail Barding, Blue" mesh="AR_horse_armor_a2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_a2_v2_h0" name="{=osa_ar_horse_armor_a2}Imperial Decorated Half Mail Barding, Blue" mesh="AR_horse_armor_a2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_roman_b_new_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_a2_v1_h1" name="{=osa_ar_horse_armor_a2}Imperial Decorated Half Mail Barding, Blue +1" mesh="AR_horse_armor_a2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_a2_v2_h1" name="{=osa_ar_horse_armor_a2}Imperial Decorated Half Mail Barding, Blue +1" mesh="AR_horse_armor_a2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_roman_b_new_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_a2_v1_h2" name="{=osa_ar_horse_armor_a2}Imperial Decorated Half Mail Barding, Blue +2" mesh="AR_horse_armor_a2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_a2_v2_h2" name="{=osa_ar_horse_armor_a2}Imperial Decorated Half Mail Barding, Blue +2" mesh="AR_horse_armor_a2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_roman_b_new_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_a2_v1_h3" name="{=osa_ar_horse_armor_a2}Imperial Decorated Half Mail Barding, Blue +3" mesh="AR_horse_armor_a2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_a2_v2_h3" name="{=osa_ar_horse_armor_a2}Imperial Decorated Half Mail Barding, Blue +3" mesh="AR_horse_armor_a2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_roman_b_new_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_b_v1_h0" name="{=osa_ar_horse_armor_b}Imperial Half Mail Barding, Red" mesh="AR_horse_armor_b" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_b_v2_h0" name="{=osa_ar_horse_armor_b}Imperial Half Mail Barding, Red" mesh="AR_horse_armor_b" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_imperial_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_b_v1_h1" name="{=osa_ar_horse_armor_b}Imperial Half Mail Barding, Red +1" mesh="AR_horse_armor_b" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_b_v2_h1" name="{=osa_ar_horse_armor_b}Imperial Half Mail Barding, Red +1" mesh="AR_horse_armor_b" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_imperial_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_b_v1_h2" name="{=osa_ar_horse_armor_b}Imperial Half Mail Barding, Red +2" mesh="AR_horse_armor_b" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_b_v2_h2" name="{=osa_ar_horse_armor_b}Imperial Half Mail Barding, Red +2" mesh="AR_horse_armor_b" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_imperial_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_b_v1_h3" name="{=osa_ar_horse_armor_b}Imperial Half Mail Barding, Red +3" mesh="AR_horse_armor_b" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_b_v2_h3" name="{=osa_ar_horse_armor_b}Imperial Half Mail Barding, Red +3" mesh="AR_horse_armor_b" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_imperial_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_b2_v1_h0" name="{=osa_ar_horse_armor_b2}Imperial Half Mail Barding, Blue" mesh="AR_horse_armor_b2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_b2_v2_h0" name="{=osa_ar_horse_armor_b2}Imperial Half Mail Barding, Blue" mesh="AR_horse_armor_b2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_roman_b_new_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_b2_v1_h1" name="{=osa_ar_horse_armor_b2}Imperial Half Mail Barding, Blue +1" mesh="AR_horse_armor_b2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_b2_v2_h1" name="{=osa_ar_horse_armor_b2}Imperial Half Mail Barding, Blue +1" mesh="AR_horse_armor_b2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_roman_b_new_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_b2_v1_h2" name="{=osa_ar_horse_armor_b2}Imperial Half Mail Barding, Blue +2" mesh="AR_horse_armor_b2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_b2_v2_h2" name="{=osa_ar_horse_armor_b2}Imperial Half Mail Barding, Blue +2" mesh="AR_horse_armor_b2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_roman_b_new_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_b2_v1_h3" name="{=osa_ar_horse_armor_b2}Imperial Half Mail Barding, Blue +3" mesh="AR_horse_armor_b2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_b2_v2_h3" name="{=osa_ar_horse_armor_b2}Imperial Half Mail Barding, Blue +3" mesh="AR_horse_armor_b2" culture="Culture.empire" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_roman_b_new_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c_v1_h0" name="{=osa_ar_horse_armor_c}Southern Scale Barding" mesh="AR_horse_armor_c" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c_v2_h0" name="{=osa_ar_horse_armor_c}Southern Scale Barding" mesh="AR_horse_armor_c" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c_v1_h1" name="{=osa_ar_horse_armor_c}Southern Scale Barding +1" mesh="AR_horse_armor_c" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c_v2_h1" name="{=osa_ar_horse_armor_c}Southern Scale Barding +1" mesh="AR_horse_armor_c" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c_v1_h2" name="{=osa_ar_horse_armor_c}Southern Scale Barding +2" mesh="AR_horse_armor_c" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c_v2_h2" name="{=osa_ar_horse_armor_c}Southern Scale Barding +2" mesh="AR_horse_armor_c" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c_v1_h3" name="{=osa_ar_horse_armor_c}Southern Scale Barding +3" mesh="AR_horse_armor_c" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c_v2_h3" name="{=osa_ar_horse_armor_c}Southern Scale Barding +3" mesh="AR_horse_armor_c" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c2_v1_h0" name="{=osa_ar_horse_armor_c2}Southern Lamellar Barding" mesh="AR_horse_armor_c2" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c2_v2_h0" name="{=osa_ar_horse_armor_c2}Southern Lamellar Barding" mesh="AR_horse_armor_c2" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c2_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c2_v1_h1" name="{=osa_ar_horse_armor_c2}Southern Lamellar Barding +1" mesh="AR_horse_armor_c2" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c2_v2_h1" name="{=osa_ar_horse_armor_c2}Southern Lamellar Barding +1" mesh="AR_horse_armor_c2" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c2_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c2_v1_h2" name="{=osa_ar_horse_armor_c2}Southern Lamellar Barding +2" mesh="AR_horse_armor_c2" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c2_v2_h2" name="{=osa_ar_horse_armor_c2}Southern Lamellar Barding +2" mesh="AR_horse_armor_c2" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c2_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c2_v1_h3" name="{=osa_ar_horse_armor_c2}Southern Lamellar Barding +3" mesh="AR_horse_armor_c2" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c2_v2_h3" name="{=osa_ar_horse_armor_c2}Southern Lamellar Barding +3" mesh="AR_horse_armor_c2" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c2_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c3_v1_h0" name="{=osa_ar_horse_armor_c3}Southern Gilded Lamellar Barding" mesh="AR_horse_armor_c3" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c3_v2_h0" name="{=osa_ar_horse_armor_c3}Southern Gilded Lamellar Barding" mesh="AR_horse_armor_c3" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c3_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c3_v1_h1" name="{=osa_ar_horse_armor_c3}Southern Gilded Lamellar Barding +1" mesh="AR_horse_armor_c3" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c3_v2_h1" name="{=osa_ar_horse_armor_c3}Southern Gilded Lamellar Barding +1" mesh="AR_horse_armor_c3" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c3_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c3_v1_h2" name="{=osa_ar_horse_armor_c3}Southern Gilded Lamellar Barding +2" mesh="AR_horse_armor_c3" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c3_v2_h2" name="{=osa_ar_horse_armor_c3}Southern Gilded Lamellar Barding +2" mesh="AR_horse_armor_c3" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c3_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_c3_v1_h3" name="{=osa_ar_horse_armor_c3}Southern Gilded Lamellar Barding +3" mesh="AR_horse_armor_c3" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_c3_v2_h3" name="{=osa_ar_horse_armor_c3}Southern Gilded Lamellar Barding +3" mesh="AR_horse_armor_c3" culture="Culture.aserai" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c3_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d_v1_h0" name="{=osa_ar_horse_armor_d}Southern Half Scale Barding" mesh="AR_horse_armor_d" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d_v2_h0" name="{=osa_ar_horse_armor_d}Southern Half Scale Barding" mesh="AR_horse_armor_d" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d_v1_h1" name="{=osa_ar_horse_armor_d}Southern Half Scale Barding +1" mesh="AR_horse_armor_d" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d_v2_h1" name="{=osa_ar_horse_armor_d}Southern Half Scale Barding +1" mesh="AR_horse_armor_d" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d_v1_h2" name="{=osa_ar_horse_armor_d}Southern Half Scale Barding +2" mesh="AR_horse_armor_d" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d_v2_h2" name="{=osa_ar_horse_armor_d}Southern Half Scale Barding +2" mesh="AR_horse_armor_d" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d_v1_h3" name="{=osa_ar_horse_armor_d}Southern Half Scale Barding +3" mesh="AR_horse_armor_d" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d_v2_h3" name="{=osa_ar_horse_armor_d}Southern Half Scale Barding +3" mesh="AR_horse_armor_d" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d2_v1_h0" name="{=osa_ar_horse_armor_d2}Southern Half Lamellar Barding" mesh="AR_horse_armor_d2" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d2_v2_h0" name="{=osa_ar_horse_armor_d2}Southern Half Lamellar Barding" mesh="AR_horse_armor_d2" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c2_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d2_v1_h1" name="{=osa_ar_horse_armor_d2}Southern Half Lamellar Barding +1" mesh="AR_horse_armor_d2" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d2_v2_h1" name="{=osa_ar_horse_armor_d2}Southern Half Lamellar Barding +1" mesh="AR_horse_armor_d2" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c2_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d2_v1_h2" name="{=osa_ar_horse_armor_d2}Southern Half Lamellar Barding +2" mesh="AR_horse_armor_d2" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d2_v2_h2" name="{=osa_ar_horse_armor_d2}Southern Half Lamellar Barding +2" mesh="AR_horse_armor_d2" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c2_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d2_v1_h3" name="{=osa_ar_horse_armor_d2}Southern Half Lamellar Barding +3" mesh="AR_horse_armor_d2" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d2_v2_h3" name="{=osa_ar_horse_armor_d2}Southern Half Lamellar Barding +3" mesh="AR_horse_armor_d2" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c2_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d3_v1_h0" name="{=osa_ar_horse_armor_d3}Southern Gilded Half Lamellar Barding" mesh="AR_horse_armor_d3" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d3_v2_h0" name="{=osa_ar_horse_armor_d3}Southern Gilded Half Lamellar Barding" mesh="AR_horse_armor_d3" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c3_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d3_v1_h1" name="{=osa_ar_horse_armor_d3}Southern Gilded Half Lamellar Barding +1" mesh="AR_horse_armor_d3" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d3_v2_h1" name="{=osa_ar_horse_armor_d3}Southern Gilded Half Lamellar Barding +1" mesh="AR_horse_armor_d3" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c3_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d3_v1_h2" name="{=osa_ar_horse_armor_d3}Southern Gilded Half Lamellar Barding +2" mesh="AR_horse_armor_d3" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d3_v2_h2" name="{=osa_ar_horse_armor_d3}Southern Gilded Half Lamellar Barding +2" mesh="AR_horse_armor_d3" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c3_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_d3_v1_h3" name="{=osa_ar_horse_armor_d3}Southern Gilded Half Lamellar Barding +3" mesh="AR_horse_armor_d3" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_d3_v2_h3" name="{=osa_ar_horse_armor_d3}Southern Gilded Half Lamellar Barding +3" mesh="AR_horse_armor_d3" culture="Culture.aserai" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="AR_horse_armor_c3_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_e_v1_h0" name="{=osa_ar_horse_armor_e}Imperial Plate with Padded Barding" mesh="AR_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_e_v2_h0" name="{=osa_ar_horse_armor_e}Imperial Plate with Padded Barding" mesh="AR_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_imperial_b_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_e_v1_h1" name="{=osa_ar_horse_armor_e}Imperial Plate with Padded Barding +1" mesh="AR_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_e_v2_h1" name="{=osa_ar_horse_armor_e}Imperial Plate with Padded Barding +1" mesh="AR_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_imperial_b_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_e_v1_h2" name="{=osa_ar_horse_armor_e}Imperial Plate with Padded Barding +2" mesh="AR_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_e_v2_h2" name="{=osa_ar_horse_armor_e}Imperial Plate with Padded Barding +2" mesh="AR_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="48" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_imperial_b_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_e_v1_h3" name="{=osa_ar_horse_armor_e}Imperial Plate with Padded Barding +3" mesh="AR_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_e_v2_h3" name="{=osa_ar_horse_armor_e}Imperial Plate with Padded Barding +3" mesh="AR_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="51" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_imperial_b_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_f_v1_h0" name="{=osa_ar_horse_armor_f}Imperial Half Plate with Padded Barding" mesh="AR_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_f_v2_h0" name="{=osa_ar_horse_armor_f}Imperial Half Plate with Padded Barding" mesh="AR_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_imperial_b_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_f_v1_h1" name="{=osa_ar_horse_armor_f}Imperial Half Plate with Padded Barding +1" mesh="AR_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_f_v2_h1" name="{=osa_ar_horse_armor_f}Imperial Half Plate with Padded Barding +1" mesh="AR_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_imperial_b_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_f_v1_h2" name="{=osa_ar_horse_armor_f}Imperial Half Plate with Padded Barding +2" mesh="AR_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_f_v2_h2" name="{=osa_ar_horse_armor_f}Imperial Half Plate with Padded Barding +2" mesh="AR_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_imperial_b_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_f_v1_h3" name="{=osa_ar_horse_armor_f}Imperial Half Plate with Padded Barding +3" mesh="AR_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_f_v2_h3" name="{=osa_ar_horse_armor_f}Imperial Half Plate with Padded Barding +3" mesh="AR_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_imperial_b_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_g_v1_h0" name="{=osa_ar_horse_armor_g}Eastern Studded Mail Barding" mesh="AR_horse_armor_g" culture="Culture.khuzait" subtype="body_armor" weight="26" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_g_v2_h0" name="{=osa_ar_horse_armor_g}Eastern Studded Mail Barding" mesh="AR_horse_armor_g" culture="Culture.khuzait" subtype="body_armor" weight="26" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="26" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_g_v1_h1" name="{=osa_ar_horse_armor_g}Eastern Studded Mail Barding +1" mesh="AR_horse_armor_g" culture="Culture.khuzait" subtype="body_armor" weight="26" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_g_v2_h1" name="{=osa_ar_horse_armor_g}Eastern Studded Mail Barding +1" mesh="AR_horse_armor_g" culture="Culture.khuzait" subtype="body_armor" weight="26" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="29" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_g_v1_h2" name="{=osa_ar_horse_armor_g}Eastern Studded Mail Barding +2" mesh="AR_horse_armor_g" culture="Culture.khuzait" subtype="body_armor" weight="26" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_g_v2_h2" name="{=osa_ar_horse_armor_g}Eastern Studded Mail Barding +2" mesh="AR_horse_armor_g" culture="Culture.khuzait" subtype="body_armor" weight="26" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_g_v1_h3" name="{=osa_ar_horse_armor_g}Eastern Studded Mail Barding +3" mesh="AR_horse_armor_g" culture="Culture.khuzait" subtype="body_armor" weight="26" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_g_v2_h3" name="{=osa_ar_horse_armor_g}Eastern Studded Mail Barding +3" mesh="AR_horse_armor_g" culture="Culture.khuzait" subtype="body_armor" weight="26" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_h_v1_h0" name="{=osa_ar_horse_armor_h}Imperial Studded Leather Barding" mesh="AR_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_h_v2_h0" name="{=osa_ar_horse_armor_h}Imperial Studded Leather Barding" mesh="AR_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="22" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_h_v1_h1" name="{=osa_ar_horse_armor_h}Imperial Studded Leather Barding +1" mesh="AR_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_h_v2_h1" name="{=osa_ar_horse_armor_h}Imperial Studded Leather Barding +1" mesh="AR_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="25" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_h_v1_h2" name="{=osa_ar_horse_armor_h}Imperial Studded Leather Barding +2" mesh="AR_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_h_v2_h2" name="{=osa_ar_horse_armor_h}Imperial Studded Leather Barding +2" mesh="AR_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="28" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_h_v1_h3" name="{=osa_ar_horse_armor_h}Imperial Studded Leather Barding +3" mesh="AR_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_h_v2_h3" name="{=osa_ar_horse_armor_h}Imperial Studded Leather Barding +3" mesh="AR_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="22" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="31" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_i_v1_h0" name="{=osa_ar_horse_armor_i}Imperial Half Leather Barding" mesh="AR_horse_armor_i" culture="Culture.empire" subtype="body_armor" weight="20" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_i_v2_h0" name="{=osa_ar_horse_armor_i}Imperial Half Leather Barding" mesh="AR_horse_armor_i" culture="Culture.empire" subtype="body_armor" weight="20" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_i_v1_h1" name="{=osa_ar_horse_armor_i}Imperial Half Leather Barding +1" mesh="AR_horse_armor_i" culture="Culture.empire" subtype="body_armor" weight="20" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_i_v2_h1" name="{=osa_ar_horse_armor_i}Imperial Half Leather Barding +1" mesh="AR_horse_armor_i" culture="Culture.empire" subtype="body_armor" weight="20" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_i_v1_h2" name="{=osa_ar_horse_armor_i}Imperial Half Leather Barding +2" mesh="AR_horse_armor_i" culture="Culture.empire" subtype="body_armor" weight="20" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_i_v2_h2" name="{=osa_ar_horse_armor_i}Imperial Half Leather Barding +2" mesh="AR_horse_armor_i" culture="Culture.empire" subtype="body_armor" weight="20" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="26" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_i_v1_h3" name="{=osa_ar_horse_armor_i}Imperial Half Leather Barding +3" mesh="AR_horse_armor_i" culture="Culture.empire" subtype="body_armor" weight="20" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_i_v2_h3" name="{=osa_ar_horse_armor_i}Imperial Half Leather Barding +3" mesh="AR_horse_armor_i" culture="Culture.empire" subtype="body_armor" weight="20" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="29" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_b_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_j_v1_h0" name="{=osa_ar_horse_armor_j}Western Half Mail Scale Barding" mesh="AR_horse_armor_j" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_j_v2_h0" name="{=osa_ar_horse_armor_j}Western Half Mail Scale Barding" mesh="AR_horse_armor_j" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_vlandia_a_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_j_v1_h1" name="{=osa_ar_horse_armor_j}Western Half Mail Scale Barding +1" mesh="AR_horse_armor_j" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_j_v2_h1" name="{=osa_ar_horse_armor_j}Western Half Mail Scale Barding +1" mesh="AR_horse_armor_j" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="47" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_vlandia_a_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_j_v1_h2" name="{=osa_ar_horse_armor_j}Western Half Mail Scale Barding +2" mesh="AR_horse_armor_j" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_j_v2_h2" name="{=osa_ar_horse_armor_j}Western Half Mail Scale Barding +2" mesh="AR_horse_armor_j" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="50" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_vlandia_a_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_j_v1_h3" name="{=osa_ar_horse_armor_j}Western Half Mail Scale Barding +3" mesh="AR_horse_armor_j" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_j_v2_h3" name="{=osa_ar_horse_armor_j}Western Half Mail Scale Barding +3" mesh="AR_horse_armor_j" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="53" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_vlandia_a_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_j2_v1_h0" name="{=osa_ar_horse_armor_j2}Western Half Mail Lamellar Barding" mesh="AR_horse_armor_j2" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_j2_v2_h0" name="{=osa_ar_horse_armor_j2}Western Half Mail Lamellar Barding" mesh="AR_horse_armor_j2" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_roman_b_new_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_j2_v1_h1" name="{=osa_ar_horse_armor_j2}Western Half Mail Lamellar Barding +1" mesh="AR_horse_armor_j2" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_j2_v2_h1" name="{=osa_ar_horse_armor_j2}Western Half Mail Lamellar Barding +1" mesh="AR_horse_armor_j2" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="47" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_roman_b_new_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_j2_v1_h2" name="{=osa_ar_horse_armor_j2}Western Half Mail Lamellar Barding +2" mesh="AR_horse_armor_j2" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_j2_v2_h2" name="{=osa_ar_horse_armor_j2}Western Half Mail Lamellar Barding +2" mesh="AR_horse_armor_j2" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="50" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_roman_b_new_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_j2_v1_h3" name="{=osa_ar_horse_armor_j2}Western Half Mail Lamellar Barding +3" mesh="AR_horse_armor_j2" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_j2_v2_h3" name="{=osa_ar_horse_armor_j2}Western Half Mail Lamellar Barding +3" mesh="AR_horse_armor_j2" culture="Culture.vlandia" subtype="body_armor" weight="44" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="53" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_roman_b_new_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_k_v1_h0" name="{=osa_ar_horse_armor_k}Western Half Padded Scale Barding" mesh="AR_horse_armor_k" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_k_v2_h0" name="{=osa_ar_horse_armor_k}Western Half Padded Scale Barding" mesh="AR_horse_armor_k" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_vlandia_a_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_k_v1_h1" name="{=osa_ar_horse_armor_k}Western Half Padded Scale Barding +1" mesh="AR_horse_armor_k" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_k_v2_h1" name="{=osa_ar_horse_armor_k}Western Half Padded Scale Barding +1" mesh="AR_horse_armor_k" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_vlandia_a_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_k_v1_h2" name="{=osa_ar_horse_armor_k}Western Half Padded Scale Barding +2" mesh="AR_horse_armor_k" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_k_v2_h2" name="{=osa_ar_horse_armor_k}Western Half Padded Scale Barding +2" mesh="AR_horse_armor_k" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="48" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_vlandia_a_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_k_v1_h3" name="{=osa_ar_horse_armor_k}Western Half Padded Scale Barding +3" mesh="AR_horse_armor_k" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_k_v2_h3" name="{=osa_ar_horse_armor_k}Western Half Padded Scale Barding +3" mesh="AR_horse_armor_k" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="51" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_vlandia_a_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_k2_v1_h0" name="{=osa_ar_horse_armor_k2}Western Half Padded Lamellar Barding" mesh="AR_horse_armor_k2" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_k2_v2_h0" name="{=osa_ar_horse_armor_k2}Western Half Padded Lamellar Barding" mesh="AR_horse_armor_k2" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_roman_b_new_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_k2_v1_h1" name="{=osa_ar_horse_armor_k2}Western Half Padded Lamellar Barding +1" mesh="AR_horse_armor_k2" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_k2_v2_h1" name="{=osa_ar_horse_armor_k2}Western Half Padded Lamellar Barding +1" mesh="AR_horse_armor_k2" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_roman_b_new_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_k2_v1_h2" name="{=osa_ar_horse_armor_k2}Western Half Padded Lamellar Barding +2" mesh="AR_horse_armor_k2" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_k2_v2_h2" name="{=osa_ar_horse_armor_k2}Western Half Padded Lamellar Barding +2" mesh="AR_horse_armor_k2" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="48" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_roman_b_new_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_k2_v1_h3" name="{=osa_ar_horse_armor_k2}Western Half Padded Lamellar Barding +3" mesh="AR_horse_armor_k2" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_k2_v2_h3" name="{=osa_ar_horse_armor_k2}Western Half Padded Lamellar Barding +3" mesh="AR_horse_armor_k2" culture="Culture.vlandia" subtype="body_armor" weight="42" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="51" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_roman_b_new_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_l_v1_h0" name="{=osa_ar_horse_armor_l}Western Leather Scale Barding" mesh="AR_horse_armor_l" culture="Culture.vlandia" subtype="body_armor" weight="20" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_l_v2_h0" name="{=osa_ar_horse_armor_l}Western Leather Scale Barding" mesh="AR_horse_armor_l" culture="Culture.vlandia" subtype="body_armor" weight="20" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_l_v1_h1" name="{=osa_ar_horse_armor_l}Western Leather Scale Barding +1" mesh="AR_horse_armor_l" culture="Culture.vlandia" subtype="body_armor" weight="20" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_l_v2_h1" name="{=osa_ar_horse_armor_l}Western Leather Scale Barding +1" mesh="AR_horse_armor_l" culture="Culture.vlandia" subtype="body_armor" weight="20" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_l_v1_h2" name="{=osa_ar_horse_armor_l}Western Leather Scale Barding +2" mesh="AR_horse_armor_l" culture="Culture.vlandia" subtype="body_armor" weight="20" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_l_v2_h2" name="{=osa_ar_horse_armor_l}Western Leather Scale Barding +2" mesh="AR_horse_armor_l" culture="Culture.vlandia" subtype="body_armor" weight="20" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="26" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_l_v1_h3" name="{=osa_ar_horse_armor_l}Western Leather Scale Barding +3" mesh="AR_horse_armor_l" culture="Culture.vlandia" subtype="body_armor" weight="20" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_l_v2_h3" name="{=osa_ar_horse_armor_l}Western Leather Scale Barding +3" mesh="AR_horse_armor_l" culture="Culture.vlandia" subtype="body_armor" weight="20" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="29" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_m_v1_h0" name="{=osa_ar_horse_armor_m}Western Half Leather Scale Barding" mesh="AR_horse_armor_m" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_m_v2_h0" name="{=osa_ar_horse_armor_m}Western Half Leather Scale Barding" mesh="AR_horse_armor_m" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_m_v1_h1" name="{=osa_ar_horse_armor_m}Western Half Leather Scale Barding +1" mesh="AR_horse_armor_m" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_m_v2_h1" name="{=osa_ar_horse_armor_m}Western Half Leather Scale Barding +1" mesh="AR_horse_armor_m" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_m_v1_h2" name="{=osa_ar_horse_armor_m}Western Half Leather Scale Barding +2" mesh="AR_horse_armor_m" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_m_v2_h2" name="{=osa_ar_horse_armor_m}Western Half Leather Scale Barding +2" mesh="AR_horse_armor_m" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_m_v1_h3" name="{=osa_ar_horse_armor_m}Western Half Leather Scale Barding +3" mesh="AR_horse_armor_m" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_m_v2_h3" name="{=osa_ar_horse_armor_m}Western Half Leather Scale Barding +3" mesh="AR_horse_armor_m" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="27" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n_v1_h0" name="{=osa_ar_horse_armor_n}Imperial Half Padded Barding, Blue" mesh="AR_horse_armor_n" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n_v2_h0" name="{=osa_ar_horse_armor_n}Imperial Half Padded Barding, Blue" mesh="AR_horse_armor_n" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n_v1_h1" name="{=osa_ar_horse_armor_n}Imperial Half Padded Barding, Blue +1" mesh="AR_horse_armor_n" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n_v2_h1" name="{=osa_ar_horse_armor_n}Imperial Half Padded Barding, Blue +1" mesh="AR_horse_armor_n" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n_v1_h2" name="{=osa_ar_horse_armor_n}Imperial Half Padded Barding, Blue +2" mesh="AR_horse_armor_n" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n_v2_h2" name="{=osa_ar_horse_armor_n}Imperial Half Padded Barding, Blue +2" mesh="AR_horse_armor_n" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n_v1_h3" name="{=osa_ar_horse_armor_n}Imperial Half Padded Barding, Blue +3" mesh="AR_horse_armor_n" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n_v2_h3" name="{=osa_ar_horse_armor_n}Imperial Half Padded Barding, Blue +3" mesh="AR_horse_armor_n" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n2_v1_h0" name="{=osa_ar_horse_armor_n2}Imperial Half Padded Barding, White" mesh="AR_horse_armor_n2" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n2_v2_h0" name="{=osa_ar_horse_armor_n2}Imperial Half Padded Barding, White" mesh="AR_horse_armor_n2" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n2_v1_h1" name="{=osa_ar_horse_armor_n2}Imperial Half Padded Barding, White +1" mesh="AR_horse_armor_n2" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n2_v2_h1" name="{=osa_ar_horse_armor_n2}Imperial Half Padded Barding, White +1" mesh="AR_horse_armor_n2" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n2_v1_h2" name="{=osa_ar_horse_armor_n2}Imperial Half Padded Barding, White +2" mesh="AR_horse_armor_n2" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n2_v2_h2" name="{=osa_ar_horse_armor_n2}Imperial Half Padded Barding, White +2" mesh="AR_horse_armor_n2" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n2_v1_h3" name="{=osa_ar_horse_armor_n2}Imperial Half Padded Barding, White +3" mesh="AR_horse_armor_n2" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n2_v2_h3" name="{=osa_ar_horse_armor_n2}Imperial Half Padded Barding, White +3" mesh="AR_horse_armor_n2" culture="Culture.empire" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n3_v1_h0" name="{=osa_ar_horse_armor_n3}Imperial Quarter Padded Barding" mesh="AR_horse_armor_n3" culture="Culture.empire" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n3_v2_h0" name="{=osa_ar_horse_armor_n3}Imperial Quarter Padded Barding" mesh="AR_horse_armor_n3" culture="Culture.empire" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_roman_b_new_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n3_v1_h1" name="{=osa_ar_horse_armor_n3}Imperial Quarter Padded Barding +1" mesh="AR_horse_armor_n3" culture="Culture.empire" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n3_v2_h1" name="{=osa_ar_horse_armor_n3}Imperial Quarter Padded Barding +1" mesh="AR_horse_armor_n3" culture="Culture.empire" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_roman_b_new_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n3_v1_h2" name="{=osa_ar_horse_armor_n3}Imperial Quarter Padded Barding +2" mesh="AR_horse_armor_n3" culture="Culture.empire" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n3_v2_h2" name="{=osa_ar_horse_armor_n3}Imperial Quarter Padded Barding +2" mesh="AR_horse_armor_n3" culture="Culture.empire" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_roman_b_new_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_n3_v1_h3" name="{=osa_ar_horse_armor_n3}Imperial Quarter Padded Barding +3" mesh="AR_horse_armor_n3" culture="Culture.empire" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_n3_v2_h3" name="{=osa_ar_horse_armor_n3}Imperial Quarter Padded Barding +3" mesh="AR_horse_armor_n3" culture="Culture.empire" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_roman_b_new_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_o_v1_h0" name="{=osa_ar_horse_armor_o}Western Half Padded Barding, Stripes" mesh="AR_horse_armor_o" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_o_v2_h0" name="{=osa_ar_horse_armor_o}Western Half Padded Barding, Stripes" mesh="AR_horse_armor_o" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_o_v1_h1" name="{=osa_ar_horse_armor_o}Western Half Padded Barding, Stripes +1" mesh="AR_horse_armor_o" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_o_v2_h1" name="{=osa_ar_horse_armor_o}Western Half Padded Barding, Stripes +1" mesh="AR_horse_armor_o" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_o_v1_h2" name="{=osa_ar_horse_armor_o}Western Half Padded Barding, Stripes +2" mesh="AR_horse_armor_o" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_o_v2_h2" name="{=osa_ar_horse_armor_o}Western Half Padded Barding, Stripes +2" mesh="AR_horse_armor_o" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_o_v1_h3" name="{=osa_ar_horse_armor_o}Western Half Padded Barding, Stripes +3" mesh="AR_horse_armor_o" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_o_v2_h3" name="{=osa_ar_horse_armor_o}Western Half Padded Barding, Stripes +3" mesh="AR_horse_armor_o" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_p_v1_h0" name="{=osa_ar_horse_armor_p}Western Heavy Padded Barding, Blue" mesh="AR_horse_armor_p" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_p_v2_h0" name="{=osa_ar_horse_armor_p}Western Heavy Padded Barding, Blue" mesh="AR_horse_armor_p" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_p_v1_h1" name="{=osa_ar_horse_armor_p}Western Heavy Padded Barding, Blue +1" mesh="AR_horse_armor_p" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_p_v2_h1" name="{=osa_ar_horse_armor_p}Western Heavy Padded Barding, Blue +1" mesh="AR_horse_armor_p" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_p_v1_h2" name="{=osa_ar_horse_armor_p}Western Heavy Padded Barding, Blue +2" mesh="AR_horse_armor_p" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_p_v2_h2" name="{=osa_ar_horse_armor_p}Western Heavy Padded Barding, Blue +2" mesh="AR_horse_armor_p" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_p_v1_h3" name="{=osa_ar_horse_armor_p}Western Heavy Padded Barding, Blue +3" mesh="AR_horse_armor_p" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_p_v2_h3" name="{=osa_ar_horse_armor_p}Western Heavy Padded Barding, Blue +3" mesh="AR_horse_armor_p" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="27" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_p2_v1_h0" name="{=osa_ar_horse_armor_p2}Western Heavy Padded Barding, Red" mesh="AR_horse_armor_p2" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_p2_v2_h0" name="{=osa_ar_horse_armor_p2}Western Heavy Padded Barding, Red" mesh="AR_horse_armor_p2" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_p2_v1_h1" name="{=osa_ar_horse_armor_p2}Western Heavy Padded Barding, Red +1" mesh="AR_horse_armor_p2" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_p2_v2_h1" name="{=osa_ar_horse_armor_p2}Western Heavy Padded Barding, Red +1" mesh="AR_horse_armor_p2" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_p2_v1_h2" name="{=osa_ar_horse_armor_p2}Western Heavy Padded Barding, Red +2" mesh="AR_horse_armor_p2" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_p2_v2_h2" name="{=osa_ar_horse_armor_p2}Western Heavy Padded Barding, Red +2" mesh="AR_horse_armor_p2" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_p2_v1_h3" name="{=osa_ar_horse_armor_p2}Western Heavy Padded Barding, Red +3" mesh="AR_horse_armor_p2" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_p2_v2_h3" name="{=osa_ar_horse_armor_p2}Western Heavy Padded Barding, Red +3" mesh="AR_horse_armor_p2" culture="Culture.vlandia" subtype="body_armor" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="27" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q_v1_h0" name="{=osa_ar_horse_armor_q}Southern Half Padded Barding" mesh="AR_horse_armor_q" culture="Culture.aserai" subtype="body_armor" weight="13" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q_v2_h0" name="{=osa_ar_horse_armor_q}Southern Half Padded Barding" mesh="AR_horse_armor_q" culture="Culture.aserai" subtype="body_armor" weight="13" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="13" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q_v1_h1" name="{=osa_ar_horse_armor_q}Southern Half Padded Barding +1" mesh="AR_horse_armor_q" culture="Culture.aserai" subtype="body_armor" weight="13" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q_v2_h1" name="{=osa_ar_horse_armor_q}Southern Half Padded Barding +1" mesh="AR_horse_armor_q" culture="Culture.aserai" subtype="body_armor" weight="13" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="16" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q_v1_h2" name="{=osa_ar_horse_armor_q}Southern Half Padded Barding +2" mesh="AR_horse_armor_q" culture="Culture.aserai" subtype="body_armor" weight="13" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q_v2_h2" name="{=osa_ar_horse_armor_q}Southern Half Padded Barding +2" mesh="AR_horse_armor_q" culture="Culture.aserai" subtype="body_armor" weight="13" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="19" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q_v1_h3" name="{=osa_ar_horse_armor_q}Southern Half Padded Barding +3" mesh="AR_horse_armor_q" culture="Culture.aserai" subtype="body_armor" weight="13" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q_v2_h3" name="{=osa_ar_horse_armor_q}Southern Half Padded Barding +3" mesh="AR_horse_armor_q" culture="Culture.aserai" subtype="body_armor" weight="13" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="22" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q2_v1_h0" name="{=osa_ar_horse_armor_q2}Southern Half Decorated Padded Barding, Hexagonal" mesh="AR_horse_armor_q2" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q2_v2_h0" name="{=osa_ar_horse_armor_q2}Southern Half Decorated Padded Barding, Hexagonal" mesh="AR_horse_armor_q2" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q2_v1_h1" name="{=osa_ar_horse_armor_q2}Southern Half Decorated Padded Barding, Hexagonal +1" mesh="AR_horse_armor_q2" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q2_v2_h1" name="{=osa_ar_horse_armor_q2}Southern Half Decorated Padded Barding, Hexagonal +1" mesh="AR_horse_armor_q2" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q2_v1_h2" name="{=osa_ar_horse_armor_q2}Southern Half Decorated Padded Barding, Hexagonal +2" mesh="AR_horse_armor_q2" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q2_v2_h2" name="{=osa_ar_horse_armor_q2}Southern Half Decorated Padded Barding, Hexagonal +2" mesh="AR_horse_armor_q2" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q2_v1_h3" name="{=osa_ar_horse_armor_q2}Southern Half Decorated Padded Barding, Hexagonal +3" mesh="AR_horse_armor_q2" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q2_v2_h3" name="{=osa_ar_horse_armor_q2}Southern Half Decorated Padded Barding, Hexagonal +3" mesh="AR_horse_armor_q2" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q3_v1_h0" name="{=osa_ar_horse_armor_q3}Southern Half Decorated Padded Barding, Squared" mesh="AR_horse_armor_q3" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q3_v2_h0" name="{=osa_ar_horse_armor_q3}Southern Half Decorated Padded Barding, Squared" mesh="AR_horse_armor_q3" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q3_v1_h1" name="{=osa_ar_horse_armor_q3}Southern Half Decorated Padded Barding, Squared +1" mesh="AR_horse_armor_q3" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q3_v2_h1" name="{=osa_ar_horse_armor_q3}Southern Half Decorated Padded Barding, Squared +1" mesh="AR_horse_armor_q3" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q3_v1_h2" name="{=osa_ar_horse_armor_q3}Southern Half Decorated Padded Barding, Squared +2" mesh="AR_horse_armor_q3" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q3_v2_h2" name="{=osa_ar_horse_armor_q3}Southern Half Decorated Padded Barding, Squared +2" mesh="AR_horse_armor_q3" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_q3_v1_h3" name="{=osa_ar_horse_armor_q3}Southern Half Decorated Padded Barding, Squared +3" mesh="AR_horse_armor_q3" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_q3_v2_h3" name="{=osa_ar_horse_armor_q3}Southern Half Decorated Padded Barding, Squared +3" mesh="AR_horse_armor_q3" culture="Culture.aserai" subtype="body_armor" weight="14" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r_v1_h0" name="{=osa_ar_horse_armor_r}Southern Padded Barding" mesh="AR_horse_armor_r" culture="Culture.aserai" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r_v2_h0" name="{=osa_ar_horse_armor_r}Southern Padded Barding" mesh="AR_horse_armor_r" culture="Culture.aserai" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r_v1_h1" name="{=osa_ar_horse_armor_r}Southern Padded Barding +1" mesh="AR_horse_armor_r" culture="Culture.aserai" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r_v2_h1" name="{=osa_ar_horse_armor_r}Southern Padded Barding +1" mesh="AR_horse_armor_r" culture="Culture.aserai" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r_v1_h2" name="{=osa_ar_horse_armor_r}Southern Padded Barding +2" mesh="AR_horse_armor_r" culture="Culture.aserai" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r_v2_h2" name="{=osa_ar_horse_armor_r}Southern Padded Barding +2" mesh="AR_horse_armor_r" culture="Culture.aserai" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r_v1_h3" name="{=osa_ar_horse_armor_r}Southern Padded Barding +3" mesh="AR_horse_armor_r" culture="Culture.aserai" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r_v2_h3" name="{=osa_ar_horse_armor_r}Southern Padded Barding +3" mesh="AR_horse_armor_r" culture="Culture.aserai" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="26" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r2_v1_h0" name="{=osa_ar_horse_armor_r2}Southern Decorated Padded Barding, Hexagonal" mesh="AR_horse_armor_r2" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r2_v2_h0" name="{=osa_ar_horse_armor_r2}Southern Decorated Padded Barding, Hexagonal" mesh="AR_horse_armor_r2" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r2_v1_h1" name="{=osa_ar_horse_armor_r2}Southern Decorated Padded Barding, Hexagonal +1" mesh="AR_horse_armor_r2" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r2_v2_h1" name="{=osa_ar_horse_armor_r2}Southern Decorated Padded Barding, Hexagonal +1" mesh="AR_horse_armor_r2" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r2_v1_h2" name="{=osa_ar_horse_armor_r2}Southern Decorated Padded Barding, Hexagonal +2" mesh="AR_horse_armor_r2" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r2_v2_h2" name="{=osa_ar_horse_armor_r2}Southern Decorated Padded Barding, Hexagonal +2" mesh="AR_horse_armor_r2" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r2_v1_h3" name="{=osa_ar_horse_armor_r2}Southern Decorated Padded Barding, Hexagonal +3" mesh="AR_horse_armor_r2" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r2_v2_h3" name="{=osa_ar_horse_armor_r2}Southern Decorated Padded Barding, Hexagonal +3" mesh="AR_horse_armor_r2" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="27" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r3_v1_h0" name="{=osa_ar_horse_armor_r3}Southern Decorated Padded Barding, Squared" mesh="AR_horse_armor_r3" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r3_v2_h0" name="{=osa_ar_horse_armor_r3}Southern Decorated Padded Barding, Squared" mesh="AR_horse_armor_r3" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r3_v1_h1" name="{=osa_ar_horse_armor_r3}Southern Decorated Padded Barding, Squared +1" mesh="AR_horse_armor_r3" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r3_v2_h1" name="{=osa_ar_horse_armor_r3}Southern Decorated Padded Barding, Squared +1" mesh="AR_horse_armor_r3" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r3_v1_h2" name="{=osa_ar_horse_armor_r3}Southern Decorated Padded Barding, Squared +2" mesh="AR_horse_armor_r3" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r3_v2_h2" name="{=osa_ar_horse_armor_r3}Southern Decorated Padded Barding, Squared +2" mesh="AR_horse_armor_r3" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_r3_v1_h3" name="{=osa_ar_horse_armor_r3}Southern Decorated Padded Barding, Squared +3" mesh="AR_horse_armor_r3" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_r3_v2_h3" name="{=osa_ar_horse_armor_r3}Southern Decorated Padded Barding, Squared +3" mesh="AR_horse_armor_r3" subtype="body_armor" culture="Culture.aserai" weight="18" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="27" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_aserai_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_s_v1_h0" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_s_v2_h0" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_s_v1_h1" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red +1" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_s_v2_h1" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red +1" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_s_v1_h2" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red +2" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_s_v2_h2" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red +2" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_s_v1_h3" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red +3" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_s_v2_h3" name="{=osa_ar_horse_armor_s}Western Heavy Harness, Red +3" mesh="AR_horse_armor_s" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_t_v1_h0" name="{=osa_ar_horse_armor_t}Southern Decorated Half Mail Barding, Diamonds" mesh="AR_horse_armor_t" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_t_v2_h0" name="{=osa_ar_horse_armor_t}Southern Decorated Half Mail Barding, Diamonds" mesh="AR_horse_armor_t" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_aserai_c_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_t_v1_h1" name="{=osa_ar_horse_armor_t}Southern Decorated Half Mail Barding, Diamonds +1" mesh="AR_horse_armor_t" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_t_v2_h1" name="{=osa_ar_horse_armor_t}Southern Decorated Half Mail Barding, Diamonds +1" mesh="AR_horse_armor_t" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_aserai_c_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_t_v1_h2" name="{=osa_ar_horse_armor_t}Southern Decorated Half Mail Barding, Diamonds +2" mesh="AR_horse_armor_t" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_t_v2_h2" name="{=osa_ar_horse_armor_t}Southern Decorated Half Mail Barding, Diamonds +2" mesh="AR_horse_armor_t" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_aserai_c_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_t_v1_h3" name="{=osa_ar_horse_armor_t}Southern Decorated Half Mail Barding, Diamonds +3" mesh="AR_horse_armor_t" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_t_v2_h3" name="{=osa_ar_horse_armor_t}Southern Decorated Half Mail Barding, Diamonds +3" mesh="AR_horse_armor_t" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_aserai_c_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_t2_v1_h0" name="{=osa_ar_horse_armor_t2}Southern Decorated Half Mail Barding, Stripes" mesh="AR_horse_armor_t2" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_t2_v2_h0" name="{=osa_ar_horse_armor_t2}Southern Decorated Half Mail Barding, Stripes" mesh="AR_horse_armor_t2" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_aserai_c_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_t2_v1_h1" name="{=osa_ar_horse_armor_t2}Southern Decorated Half Mail Barding, Stripes +1" mesh="AR_horse_armor_t2" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_t2_v2_h1" name="{=osa_ar_horse_armor_t2}Southern Decorated Half Mail Barding, Stripes +1" mesh="AR_horse_armor_t2" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_aserai_c_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_t2_v1_h2" name="{=osa_ar_horse_armor_t2}Southern Decorated Half Mail Barding, Stripes +2" mesh="AR_horse_armor_t2" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_t2_v2_h2" name="{=osa_ar_horse_armor_t2}Southern Decorated Half Mail Barding, Stripes +2" mesh="AR_horse_armor_t2" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_aserai_c_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_t2_v1_h3" name="{=osa_ar_horse_armor_t2}Southern Decorated Half Mail Barding, Stripes +3" mesh="AR_horse_armor_t2" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_t2_v2_h3" name="{=osa_ar_horse_armor_t2}Southern Decorated Half Mail Barding, Stripes +3" mesh="AR_horse_armor_t2" culture="Culture.aserai" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_aserai_c_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_u_v1_h0" name="{=osa_ar_horse_armor_u}Southern Half Mail Barding, Diamonds" mesh="AR_horse_armor_u" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_u_v2_h0" name="{=osa_ar_horse_armor_u}Southern Half Mail Barding, Diamonds" mesh="AR_horse_armor_u" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="29" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_u_v1_h1" name="{=osa_ar_horse_armor_u}Southern Half Mail Barding, Diamonds +1" mesh="AR_horse_armor_u" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_u_v2_h1" name="{=osa_ar_horse_armor_u}Southern Half Mail Barding, Diamonds +1" mesh="AR_horse_armor_u" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_u_v1_h2" name="{=osa_ar_horse_armor_u}Southern Half Mail Barding, Diamonds +2" mesh="AR_horse_armor_u" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_u_v2_h2" name="{=osa_ar_horse_armor_u}Southern Half Mail Barding, Diamonds +2" mesh="AR_horse_armor_u" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_u_v1_h3" name="{=osa_ar_horse_armor_u}Southern Half Mail Barding, Diamonds +3" mesh="AR_horse_armor_u" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_u_v2_h3" name="{=osa_ar_horse_armor_u}Southern Half Mail Barding, Diamonds +3" mesh="AR_horse_armor_u" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_u2_v1_h0" name="{=osa_ar_horse_armor_u2}Southern Half Mail Barding, Stripes" mesh="AR_horse_armor_u2" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_u2_v2_h0" name="{=osa_ar_horse_armor_u2}Southern Half Mail Barding, Stripes" mesh="AR_horse_armor_u2" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="29" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_u2_v1_h1" name="{=osa_ar_horse_armor_u2}Southern Half Mail Barding, Stripes +1" mesh="AR_horse_armor_u2" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_u2_v2_h1" name="{=osa_ar_horse_armor_u2}Southern Half Mail Barding, Stripes +1" mesh="AR_horse_armor_u2" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_u2_v1_h2" name="{=osa_ar_horse_armor_u2}Southern Half Mail Barding, Stripes +2" mesh="AR_horse_armor_u2" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_u2_v2_h2" name="{=osa_ar_horse_armor_u2}Southern Half Mail Barding, Stripes +2" mesh="AR_horse_armor_u2" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_u2_v1_h3" name="{=osa_ar_horse_armor_u2}Southern Half Mail Barding, Stripes +3" mesh="AR_horse_armor_u2" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_u2_v2_h3" name="{=osa_ar_horse_armor_u2}Southern Half Mail Barding, Stripes +3" mesh="AR_horse_armor_u2" culture="Culture.aserai" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_v_v1_h0" name="{=osa_ar_horse_armor_v}Eastern Half Iron Plate Barding" mesh="AR_horse_armor_v" culture="Culture.khuzait" subtype="body_armor" weight="32" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_v_v2_h0" name="{=osa_ar_horse_armor_v}Eastern Half Iron Plate Barding" mesh="AR_horse_armor_v" culture="Culture.khuzait" subtype="body_armor" weight="32" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_v_v1_h1" name="{=osa_ar_horse_armor_v}Eastern Half Iron Plate Barding +1" mesh="AR_horse_armor_v" culture="Culture.khuzait" subtype="body_armor" weight="32" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_v_v2_h1" name="{=osa_ar_horse_armor_v}Eastern Half Iron Plate Barding +1" mesh="AR_horse_armor_v" culture="Culture.khuzait" subtype="body_armor" weight="32" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_v_v1_h2" name="{=osa_ar_horse_armor_v}Eastern Half Iron Plate Barding +2" mesh="AR_horse_armor_v" culture="Culture.khuzait" subtype="body_armor" weight="32" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_v_v2_h2" name="{=osa_ar_horse_armor_v}Eastern Half Iron Plate Barding +2" mesh="AR_horse_armor_v" culture="Culture.khuzait" subtype="body_armor" weight="32" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_v_v1_h3" name="{=osa_ar_horse_armor_v}Eastern Half Iron Plate Barding +3" mesh="AR_horse_armor_v" culture="Culture.khuzait" subtype="body_armor" weight="32" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_v_v2_h3" name="{=osa_ar_horse_armor_v}Eastern Half Iron Plate Barding +3" mesh="AR_horse_armor_v" culture="Culture.khuzait" subtype="body_armor" weight="32" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_w_v1_h0" name="{=osa_ar_horse_armor_w}Eastern Reinforced Iron Plate Barding" mesh="AR_horse_armor_w" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_w_v2_h0" name="{=osa_ar_horse_armor_w}Eastern Reinforced Iron Plate Barding" mesh="AR_horse_armor_w" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_w_v1_h1" name="{=osa_ar_horse_armor_w}Eastern Reinforced Iron Plate Barding +1" mesh="AR_horse_armor_w" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_w_v2_h1" name="{=osa_ar_horse_armor_w}Eastern Reinforced Iron Plate Barding +1" mesh="AR_horse_armor_w" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_w_v1_h2" name="{=osa_ar_horse_armor_w}Eastern Reinforced Iron Plate Barding +2" mesh="AR_horse_armor_w" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_w_v2_h2" name="{=osa_ar_horse_armor_w}Eastern Reinforced Iron Plate Barding +2" mesh="AR_horse_armor_w" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_w_v1_h3" name="{=osa_ar_horse_armor_w}Eastern Reinforced Iron Plate Barding +3" mesh="AR_horse_armor_w" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_w_v2_h3" name="{=osa_ar_horse_armor_w}Eastern Reinforced Iron Plate Barding +3" mesh="AR_horse_armor_w" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_x_v1_h0" name="{=osa_ar_horse_armor_x}Eastern Reinforced Iron Plate and Mail Barding" mesh="AR_horse_armor_x" culture="Culture.khuzait" subtype="body_armor" weight="38" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_x_v2_h0" name="{=osa_ar_horse_armor_x}Eastern Reinforced Iron Plate and Mail Barding" mesh="AR_horse_armor_x" culture="Culture.khuzait" subtype="body_armor" weight="38" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_x_v1_h1" name="{=osa_ar_horse_armor_x}Eastern Reinforced Iron Plate and Mail Barding +1" mesh="AR_horse_armor_x" culture="Culture.khuzait" subtype="body_armor" weight="38" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_x_v2_h1" name="{=osa_ar_horse_armor_x}Eastern Reinforced Iron Plate and Mail Barding +1" mesh="AR_horse_armor_x" culture="Culture.khuzait" subtype="body_armor" weight="38" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_x_v1_h2" name="{=osa_ar_horse_armor_x}Eastern Reinforced Iron Plate and Mail Barding +2" mesh="AR_horse_armor_x" culture="Culture.khuzait" subtype="body_armor" weight="38" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_x_v2_h2" name="{=osa_ar_horse_armor_x}Eastern Reinforced Iron Plate and Mail Barding +2" mesh="AR_horse_armor_x" culture="Culture.khuzait" subtype="body_armor" weight="38" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_x_v1_h3" name="{=osa_ar_horse_armor_x}Eastern Reinforced Iron Plate and Mail Barding +3" mesh="AR_horse_armor_x" culture="Culture.khuzait" subtype="body_armor" weight="38" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_x_v2_h3" name="{=osa_ar_horse_armor_x}Eastern Reinforced Iron Plate and Mail Barding +3" mesh="AR_horse_armor_x" culture="Culture.khuzait" subtype="body_armor" weight="38" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="47" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y_v1_h0" name="{=osa_ar_horse_armor_y}Eastern Half Lamellar Barding" mesh="AR_horse_armor_y" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y_v2_h0" name="{=osa_ar_horse_armor_y}Eastern Half Lamellar Barding" mesh="AR_horse_armor_y" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y_v1_h1" name="{=osa_ar_horse_armor_y}Eastern Half Lamellar Barding +1" mesh="AR_horse_armor_y" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y_v2_h1" name="{=osa_ar_horse_armor_y}Eastern Half Lamellar Barding +1" mesh="AR_horse_armor_y" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y_v1_h2" name="{=osa_ar_horse_armor_y}Eastern Half Lamellar Barding +2" mesh="AR_horse_armor_y" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y_v2_h2" name="{=osa_ar_horse_armor_y}Eastern Half Lamellar Barding +2" mesh="AR_horse_armor_y" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y_v1_h3" name="{=osa_ar_horse_armor_y}Eastern Half Lamellar Barding +3" mesh="AR_horse_armor_y" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y_v2_h3" name="{=osa_ar_horse_armor_y}Eastern Half Lamellar Barding +3" mesh="AR_horse_armor_y" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y2_v1_h0" name="{=osa_ar_horse_armor_y2}Eastern Half Studded Barding" mesh="AR_horse_armor_y2" culture="Culture.khuzait" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y2_v2_h0" name="{=osa_ar_horse_armor_y2}Eastern Half Studded Barding" mesh="AR_horse_armor_y2" culture="Culture.khuzait" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_khuzait_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y2_v1_h1" name="{=osa_ar_horse_armor_y2}Eastern Half Studded Barding +1" mesh="AR_horse_armor_y2" culture="Culture.khuzait" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y2_v2_h1" name="{=osa_ar_horse_armor_y2}Eastern Half Studded Barding +1" mesh="AR_horse_armor_y2" culture="Culture.khuzait" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_khuzait_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y2_v1_h2" name="{=osa_ar_horse_armor_y2}Eastern Half Studded Barding +2" mesh="AR_horse_armor_y2" culture="Culture.khuzait" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y2_v2_h2" name="{=osa_ar_horse_armor_y2}Eastern Half Studded Barding +2" mesh="AR_horse_armor_y2" culture="Culture.khuzait" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_khuzait_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y2_v1_h3" name="{=osa_ar_horse_armor_y2}Eastern Half Studded Barding +3" mesh="AR_horse_armor_y2" culture="Culture.khuzait" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y2_v2_h3" name="{=osa_ar_horse_armor_y2}Eastern Half Studded Barding +3" mesh="AR_horse_armor_y2" culture="Culture.khuzait" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="26" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_khuzait_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y3_v1_h0" name="{=osa_ar_horse_armor_y3}Eastern Half Alternating Lamellar Barding" mesh="AR_horse_armor_y3" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y3_v2_h0" name="{=osa_ar_horse_armor_y3}Eastern Half Alternating Lamellar Barding" mesh="AR_horse_armor_y3" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y3_v1_h1" name="{=osa_ar_horse_armor_y3}Eastern Half Alternating Lamellar Barding +1" mesh="AR_horse_armor_y3" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y3_v2_h1" name="{=osa_ar_horse_armor_y3}Eastern Half Alternating Lamellar Barding +1" mesh="AR_horse_armor_y3" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y3_v1_h2" name="{=osa_ar_horse_armor_y3}Eastern Half Alternating Lamellar Barding +2" mesh="AR_horse_armor_y3" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y3_v2_h2" name="{=osa_ar_horse_armor_y3}Eastern Half Alternating Lamellar Barding +2" mesh="AR_horse_armor_y3" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_y3_v1_h3" name="{=osa_ar_horse_armor_y3}Eastern Half Alternating Lamellar Barding +3" mesh="AR_horse_armor_y3" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_y3_v2_h3" name="{=osa_ar_horse_armor_y3}Eastern Half Alternating Lamellar Barding +3" mesh="AR_horse_armor_y3" culture="Culture.khuzait" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z_v1_h0" name="{=osa_ar_horse_armor_z}Eastern Lamellar Barding" mesh="AR_horse_armor_z" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z_v2_h0" name="{=osa_ar_horse_armor_z}Eastern Lamellar Barding" mesh="AR_horse_armor_z" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z_v1_h1" name="{=osa_ar_horse_armor_z}Eastern Lamellar Barding +1" mesh="AR_horse_armor_z" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z_v2_h1" name="{=osa_ar_horse_armor_z}Eastern Lamellar Barding +1" mesh="AR_horse_armor_z" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z_v1_h2" name="{=osa_ar_horse_armor_z}Eastern Lamellar Barding +2" mesh="AR_horse_armor_z" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z_v2_h2" name="{=osa_ar_horse_armor_z}Eastern Lamellar Barding +2" mesh="AR_horse_armor_z" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z_v1_h3" name="{=osa_ar_horse_armor_z}Eastern Lamellar Barding +3" mesh="AR_horse_armor_z" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z_v2_h3" name="{=osa_ar_horse_armor_z}Eastern Lamellar Barding +3" mesh="AR_horse_armor_z" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z2_v1_h0" name="{=osa_ar_horse_armor_z2}Eastern Studded Barding" mesh="AR_horse_armor_z2" culture="Culture.khuzait" subtype="body_armor" weight="21" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z2_v2_h0" name="{=osa_ar_horse_armor_z2}Eastern Studded Barding" mesh="AR_horse_armor_z2" culture="Culture.khuzait" subtype="body_armor" weight="21" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_khuzait_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z2_v1_h1" name="{=osa_ar_horse_armor_z2}Eastern Studded Barding +1" mesh="AR_horse_armor_z2" culture="Culture.khuzait" subtype="body_armor" weight="21" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z2_v2_h1" name="{=osa_ar_horse_armor_z2}Eastern Studded Barding +1" mesh="AR_horse_armor_z2" culture="Culture.khuzait" subtype="body_armor" weight="21" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_khuzait_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z2_v1_h2" name="{=osa_ar_horse_armor_z2}Eastern Studded Barding +2" mesh="AR_horse_armor_z2" culture="Culture.khuzait" subtype="body_armor" weight="21" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z2_v2_h2" name="{=osa_ar_horse_armor_z2}Eastern Studded Barding +2" mesh="AR_horse_armor_z2" culture="Culture.khuzait" subtype="body_armor" weight="21" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="27" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_khuzait_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z2_v1_h3" name="{=osa_ar_horse_armor_z2}Eastern Studded Barding +3" mesh="AR_horse_armor_z2" culture="Culture.khuzait" subtype="body_armor" weight="21" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z2_v2_h3" name="{=osa_ar_horse_armor_z2}Eastern Studded Barding +3" mesh="AR_horse_armor_z2" culture="Culture.khuzait" subtype="body_armor" weight="21" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_khuzait_c_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z3_v1_h0" name="{=osa_ar_horse_armor_z3}Eastern Alternating Lamellar Barding" mesh="AR_horse_armor_z3" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z3_v2_h0" name="{=osa_ar_horse_armor_z3}Eastern Alternating Lamellar Barding" mesh="AR_horse_armor_z3" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z3_v1_h1" name="{=osa_ar_horse_armor_z3}Eastern Alternating Lamellar Barding +1" mesh="AR_horse_armor_z3" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z3_v2_h1" name="{=osa_ar_horse_armor_z3}Eastern Alternating Lamellar Barding +1" mesh="AR_horse_armor_z3" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z3_v1_h2" name="{=osa_ar_horse_armor_z3}Eastern Alternating Lamellar Barding +2" mesh="AR_horse_armor_z3" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z3_v2_h2" name="{=osa_ar_horse_armor_z3}Eastern Alternating Lamellar Barding +2" mesh="AR_horse_armor_z3" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_z3_v1_h3" name="{=osa_ar_horse_armor_z3}Eastern Alternating Lamellar Barding +3" mesh="AR_horse_armor_z3" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_z3_v2_h3" name="{=osa_ar_horse_armor_z3}Eastern Alternating Lamellar Barding +3" mesh="AR_horse_armor_z3" culture="Culture.khuzait" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaa_v1_h0" name="{=osa_ar_horse_armor_zaa}Imperial Gilded Half Scale Barding" mesh="AR_horse_armor_zaa" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaa_v2_h0" name="{=osa_ar_horse_armor_zaa}Imperial Gilded Half Scale Barding" mesh="AR_horse_armor_zaa" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zaa_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaa_v1_h1" name="{=osa_ar_horse_armor_zaa}Imperial Gilded Half Scale Barding +1" mesh="AR_horse_armor_zaa" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaa_v2_h1" name="{=osa_ar_horse_armor_zaa}Imperial Gilded Half Scale Barding +1" mesh="AR_horse_armor_zaa" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zaa_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaa_v1_h2" name="{=osa_ar_horse_armor_zaa}Imperial Gilded Half Scale Barding +2" mesh="AR_horse_armor_zaa" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaa_v2_h2" name="{=osa_ar_horse_armor_zaa}Imperial Gilded Half Scale Barding +2" mesh="AR_horse_armor_zaa" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zaa_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaa_v1_h3" name="{=osa_ar_horse_armor_zaa}Imperial Gilded Half Scale Barding +3" mesh="AR_horse_armor_zaa" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaa_v2_h3" name="{=osa_ar_horse_armor_zaa}Imperial Gilded Half Scale Barding +3" mesh="AR_horse_armor_zaa" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zaa_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zab_v1_h0" name="{=osa_ar_horse_armor_zab}Imperial Gilded Scale Barding" mesh="AR_horse_armor_zab" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zab_v2_h0" name="{=osa_ar_horse_armor_zab}Imperial Gilded Scale Barding" mesh="AR_horse_armor_zab" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zaa_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zab_v1_h1" name="{=osa_ar_horse_armor_zab}Imperial Gilded Scale Barding +1" mesh="AR_horse_armor_zab" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zab_v2_h1" name="{=osa_ar_horse_armor_zab}Imperial Gilded Scale Barding +1" mesh="AR_horse_armor_zab" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zaa_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zab_v1_h2" name="{=osa_ar_horse_armor_zab}Imperial Gilded Scale Barding +2" mesh="AR_horse_armor_zab" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zab_v2_h2" name="{=osa_ar_horse_armor_zab}Imperial Gilded Scale Barding +2" mesh="AR_horse_armor_zab" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zaa_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zab_v1_h3" name="{=osa_ar_horse_armor_zab}Imperial Gilded Scale Barding +3" mesh="AR_horse_armor_zab" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zab_v2_h3" name="{=osa_ar_horse_armor_zab}Imperial Gilded Scale Barding +3" mesh="AR_horse_armor_zab" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zaa_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zac_v1_h0" name="{=osa_ar_horse_armor_zac}Imperial Silvered Half Scale Barding" mesh="AR_horse_armor_zac" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zac_v2_h0" name="{=osa_ar_horse_armor_zac}Imperial Silvered Half Scale Barding" mesh="AR_horse_armor_zac" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zac_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zac_v1_h1" name="{=osa_ar_horse_armor_zac}Imperial Silvered Half Scale Barding +1" mesh="AR_horse_armor_zac" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zac_v2_h1" name="{=osa_ar_horse_armor_zac}Imperial Silvered Half Scale Barding +1" mesh="AR_horse_armor_zac" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zac_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zac_v1_h2" name="{=osa_ar_horse_armor_zac}Imperial Silvered Half Scale Barding +2" mesh="AR_horse_armor_zac" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zac_v2_h2" name="{=osa_ar_horse_armor_zac}Imperial Silvered Half Scale Barding +2" mesh="AR_horse_armor_zac" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zac_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zac_v1_h3" name="{=osa_ar_horse_armor_zac}Imperial Silvered Half Scale Barding +3" mesh="AR_horse_armor_zac" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zac_v2_h3" name="{=osa_ar_horse_armor_zac}Imperial Silvered Half Scale Barding +3" mesh="AR_horse_armor_zac" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zac_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zad_v1_h0" name="{=osa_ar_horse_armor_zad}Imperial Silvered Scale Barding" mesh="AR_horse_armor_zad" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zad_v2_h0" name="{=osa_ar_horse_armor_zad}Imperial Silvered Scale Barding" mesh="AR_horse_armor_zad" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zac_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zad_v1_h1" name="{=osa_ar_horse_armor_zad}Imperial Silvered Scale Barding +1" mesh="AR_horse_armor_zad" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zad_v2_h1" name="{=osa_ar_horse_armor_zad}Imperial Silvered Scale Barding +1" mesh="AR_horse_armor_zad" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zac_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zad_v1_h2" name="{=osa_ar_horse_armor_zad}Imperial Silvered Scale Barding +2" mesh="AR_horse_armor_zad" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zad_v2_h2" name="{=osa_ar_horse_armor_zad}Imperial Silvered Scale Barding +2" mesh="AR_horse_armor_zad" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zac_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zad_v1_h3" name="{=osa_ar_horse_armor_zad}Imperial Silvered Scale Barding +3" mesh="AR_horse_armor_zad" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zad_v2_h3" name="{=osa_ar_horse_armor_zad}Imperial Silvered Scale Barding +3" mesh="AR_horse_armor_zad" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" reins_mesh="AR_horse_armor_zac_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zae_v1_h0" name="{=osa_ar_horse_armor_zae}Northern Iron Scale Barding" mesh="AR_horse_armor_zae" culture="Culture.sturgia" weight="32" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zae_v2_h0" name="{=osa_ar_horse_armor_zae}Northern Iron Scale Barding" mesh="AR_horse_armor_zae" culture="Culture.sturgia" weight="32" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zae_v1_h1" name="{=osa_ar_horse_armor_zae}Northern Iron Scale Barding +1" mesh="AR_horse_armor_zae" culture="Culture.sturgia" weight="32" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zae_v2_h1" name="{=osa_ar_horse_armor_zae}Northern Iron Scale Barding +1" mesh="AR_horse_armor_zae" culture="Culture.sturgia" weight="32" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zae_v1_h2" name="{=osa_ar_horse_armor_zae}Northern Iron Scale Barding +2" mesh="AR_horse_armor_zae" culture="Culture.sturgia" weight="32" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zae_v2_h2" name="{=osa_ar_horse_armor_zae}Northern Iron Scale Barding +2" mesh="AR_horse_armor_zae" culture="Culture.sturgia" weight="32" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zae_v1_h3" name="{=osa_ar_horse_armor_zae}Northern Iron Scale Barding +3" mesh="AR_horse_armor_zae" culture="Culture.sturgia" weight="32" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zae_v2_h3" name="{=osa_ar_horse_armor_zae}Northern Iron Scale Barding +3" mesh="AR_horse_armor_zae" culture="Culture.sturgia" weight="32" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zae2_v1_h0" name="{=osa_ar_horse_armor_zae2}Northern Steel Scale Barding" mesh="AR_horse_armor_zae2" culture="Culture.sturgia" weight="36" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zae2_v2_h0" name="{=osa_ar_horse_armor_zae2}Northern Steel Scale Barding" mesh="AR_horse_armor_zae2" culture="Culture.sturgia" weight="36" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zae2_v1_h1" name="{=osa_ar_horse_armor_zae2}Northern Steel Scale Barding +1" mesh="AR_horse_armor_zae2" culture="Culture.sturgia" weight="36" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zae2_v2_h1" name="{=osa_ar_horse_armor_zae2}Northern Steel Scale Barding +1" mesh="AR_horse_armor_zae2" culture="Culture.sturgia" weight="36" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zae2_v1_h2" name="{=osa_ar_horse_armor_zae2}Northern Steel Scale Barding +2" mesh="AR_horse_armor_zae2" culture="Culture.sturgia" weight="36" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zae2_v2_h2" name="{=osa_ar_horse_armor_zae2}Northern Steel Scale Barding +2" mesh="AR_horse_armor_zae2" culture="Culture.sturgia" weight="36" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zae2_v1_h3" name="{=osa_ar_horse_armor_zae2}Northern Steel Scale Barding +3" mesh="AR_horse_armor_zae2" culture="Culture.sturgia" weight="36" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zae2_v2_h3" name="{=osa_ar_horse_armor_zae2}Northern Steel Scale Barding +3" mesh="AR_horse_armor_zae2" culture="Culture.sturgia" weight="36" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaf_v1_h0" name="{=osa_ar_horse_armor_zaf}Northern Ringed Mail Barding" mesh="AR_horse_armor_zaf" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaf_v2_h0" name="{=osa_ar_horse_armor_zaf}Northern Ringed Mail Barding" mesh="AR_horse_armor_zaf" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="28" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaf_v1_h1" name="{=osa_ar_horse_armor_zaf}Northern Ringed Mail Barding +1" mesh="AR_horse_armor_zaf" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaf_v2_h1" name="{=osa_ar_horse_armor_zaf}Northern Ringed Mail Barding +1" mesh="AR_horse_armor_zaf" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="31" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaf_v1_h2" name="{=osa_ar_horse_armor_zaf}Northern Ringed Mail Barding +2" mesh="AR_horse_armor_zaf" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaf_v2_h2" name="{=osa_ar_horse_armor_zaf}Northern Ringed Mail Barding +2" mesh="AR_horse_armor_zaf" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaf_v1_h3" name="{=osa_ar_horse_armor_zaf}Northern Ringed Mail Barding +3" mesh="AR_horse_armor_zaf" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaf_v2_h3" name="{=osa_ar_horse_armor_zaf}Northern Ringed Mail Barding +3" mesh="AR_horse_armor_zaf" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="37" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zag_v1_h0" name="{=osa_ar_horse_armor_zag}Northern Chainmail Barding" mesh="AR_horse_armor_zag" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zag_v2_h0" name="{=osa_ar_horse_armor_zag}Northern Chainmail Barding" mesh="AR_horse_armor_zag" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="28" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zag_v1_h1" name="{=osa_ar_horse_armor_zag}Northern Chainmail Barding +1" mesh="AR_horse_armor_zag" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zag_v2_h1" name="{=osa_ar_horse_armor_zag}Northern Chainmail Barding +1" mesh="AR_horse_armor_zag" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="31" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zag_v1_h2" name="{=osa_ar_horse_armor_zag}Northern Chainmail Barding +2" mesh="AR_horse_armor_zag" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zag_v2_h2" name="{=osa_ar_horse_armor_zag}Northern Chainmail Barding +2" mesh="AR_horse_armor_zag" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zag_v1_h3" name="{=osa_ar_horse_armor_zag}Northern Chainmail Barding +3" mesh="AR_horse_armor_zag" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zag_v2_h3" name="{=osa_ar_horse_armor_zag}Northern Chainmail Barding +3" mesh="AR_horse_armor_zag" culture="Culture.sturgia" weight="28" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="37" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zah_v1_h0" name="{=osa_ar_horse_armor_zah}Western Harness, Blue" mesh="AR_horse_armor_zah" weight="8" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_zah_v2_h0" name="{=osa_ar_horse_armor_zah}Western Harness, Blue" mesh="AR_horse_armor_zah" weight="8" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="8" reins_mesh="horse_harness_imperial_a_rein" mane_cover_type="none" maneuver_bonus="0" speed_bonus="0" charge_bonus="0" family_type="1" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zah_v1_h1" name="{=osa_ar_horse_armor_zah}Western Harness, Blue +1" mesh="AR_horse_armor_zah" weight="8" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_zah_v2_h1" name="{=osa_ar_horse_armor_zah}Western Harness, Blue +1" mesh="AR_horse_armor_zah" weight="8" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="11" reins_mesh="horse_harness_imperial_a_rein" mane_cover_type="none" maneuver_bonus="0" speed_bonus="0" charge_bonus="0" family_type="1" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zah_v1_h2" name="{=osa_ar_horse_armor_zah}Western Harness, Blue +2" mesh="AR_horse_armor_zah" weight="8" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_zah_v2_h2" name="{=osa_ar_horse_armor_zah}Western Harness, Blue +2" mesh="AR_horse_armor_zah" weight="8" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="14" reins_mesh="horse_harness_imperial_a_rein" mane_cover_type="none" maneuver_bonus="0" speed_bonus="0" charge_bonus="0" family_type="1" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zah_v1_h3" name="{=osa_ar_horse_armor_zah}Western Harness, Blue +3" mesh="AR_horse_armor_zah" weight="8" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_zah_v2_h3" name="{=osa_ar_horse_armor_zah}Western Harness, Blue +3" mesh="AR_horse_armor_zah" weight="8" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="17" reins_mesh="horse_harness_imperial_a_rein" mane_cover_type="none" maneuver_bonus="0" speed_bonus="0" charge_bonus="0" family_type="1" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zai_v1_h0" name="{=osa_ar_horse_armor_zai}Western Heavy Harness, Blue" mesh="AR_horse_armor_zah" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_zai_v2_h0" name="{=osa_ar_horse_armor_zai}Western Heavy Harness, Blue" mesh="AR_horse_armor_zah" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zai_v1_h1" name="{=osa_ar_horse_armor_zai}Western Heavy Harness, Blue +1" mesh="AR_horse_armor_zah" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_zai_v2_h1" name="{=osa_ar_horse_armor_zai}Western Heavy Harness, Blue +1" mesh="AR_horse_armor_zah" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zai_v1_h2" name="{=osa_ar_horse_armor_zai}Western Heavy Harness, Blue +2" mesh="AR_horse_armor_zah" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_zai_v2_h2" name="{=osa_ar_horse_armor_zai}Western Heavy Harness, Blue +2" mesh="AR_horse_armor_zah" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zai_v1_h3" name="{=osa_ar_horse_armor_zai}Western Heavy Harness, Blue +3" mesh="AR_horse_armor_zah" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
+  <Item id="crpg_ar_horse_armor_zai_v2_h3" name="{=osa_ar_horse_armor_zai}Western Heavy Harness, Blue +3" mesh="AR_horse_armor_zah" subtype="body_armor" weight="9" appearance="1" Type="HorseHarness" culture="Culture.vlandia">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_vlandia_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaj_v1_h0" name="{=osa_ar_horse_armor_zaj}Western Padded Barding, Stripes" mesh="AR_horse_armor_zaj" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaj_v2_h0" name="{=osa_ar_horse_armor_zaj}Western Padded Barding, Stripes" mesh="AR_horse_armor_zaj" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaj_v1_h1" name="{=osa_ar_horse_armor_zaj}Western Padded Barding, Stripes +1" mesh="AR_horse_armor_zaj" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaj_v2_h1" name="{=osa_ar_horse_armor_zaj}Western Padded Barding, Stripes +1" mesh="AR_horse_armor_zaj" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaj_v1_h2" name="{=osa_ar_horse_armor_zaj}Western Padded Barding, Stripes +2" mesh="AR_horse_armor_zaj" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaj_v2_h2" name="{=osa_ar_horse_armor_zaj}Western Padded Barding, Stripes +2" mesh="AR_horse_armor_zaj" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaj_v1_h3" name="{=osa_ar_horse_armor_zaj}Western Padded Barding, Stripes +3" mesh="AR_horse_armor_zaj" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaj_v2_h3" name="{=osa_ar_horse_armor_zaj}Western Padded Barding, Stripes +3" mesh="AR_horse_armor_zaj" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="26" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zak_v1_h0" name="{=osa_ar_horse_armor_zak}Western 3/4 Padded Barding, Stripes" mesh="AR_horse_armor_zak" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zak_v2_h0" name="{=osa_ar_horse_armor_zak}Western 3/4 Padded Barding, Stripes" mesh="AR_horse_armor_zak" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zak_v1_h1" name="{=osa_ar_horse_armor_zak}Western 3/4 Padded Barding, Stripes +1" mesh="AR_horse_armor_zak" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zak_v2_h1" name="{=osa_ar_horse_armor_zak}Western 3/4 Padded Barding, Stripes +1" mesh="AR_horse_armor_zak" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zak_v1_h2" name="{=osa_ar_horse_armor_zak}Western 3/4 Padded Barding, Stripes +2" mesh="AR_horse_armor_zak" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zak_v2_h2" name="{=osa_ar_horse_armor_zak}Western 3/4 Padded Barding, Stripes +2" mesh="AR_horse_armor_zak" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zak_v1_h3" name="{=osa_ar_horse_armor_zak}Western 3/4 Padded Barding, Stripes +3" mesh="AR_horse_armor_zak" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zak_v2_h3" name="{=osa_ar_horse_armor_zak}Western 3/4 Padded Barding, Stripes +3" mesh="AR_horse_armor_zak" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zal_v1_h0" name="{=osa_ar_horse_armor_zal}Western Quarter Padded Barding, Stripes" mesh="AR_horse_armor_zal" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zal_v2_h0" name="{=osa_ar_horse_armor_zal}Western Quarter Padded Barding, Stripes" mesh="AR_horse_armor_zal" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="11" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zal_v1_h1" name="{=osa_ar_horse_armor_zal}Western Quarter Padded Barding, Stripes +1" mesh="AR_horse_armor_zal" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zal_v2_h1" name="{=osa_ar_horse_armor_zal}Western Quarter Padded Barding, Stripes +1" mesh="AR_horse_armor_zal" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zal_v1_h2" name="{=osa_ar_horse_armor_zal}Western Quarter Padded Barding, Stripes +2" mesh="AR_horse_armor_zal" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zal_v2_h2" name="{=osa_ar_horse_armor_zal}Western Quarter Padded Barding, Stripes +2" mesh="AR_horse_armor_zal" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zal_v1_h3" name="{=osa_ar_horse_armor_zal}Western Quarter Padded Barding, Stripes +3" mesh="AR_horse_armor_zal" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zal_v2_h3" name="{=osa_ar_horse_armor_zal}Western Quarter Padded Barding, Stripes +3" mesh="AR_horse_armor_zal" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zam_v1_h0" name="{=osa_ar_horse_armor_zam}Western Heavy Padded Mail Barding" mesh="AR_horse_armor_zam" culture="Culture.vlandia" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zam_v2_h0" name="{=osa_ar_horse_armor_zam}Western Heavy Padded Mail Barding" mesh="AR_horse_armor_zam" culture="Culture.vlandia" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zam_v1_h1" name="{=osa_ar_horse_armor_zam}Western Heavy Padded Mail Barding +1" mesh="AR_horse_armor_zam" culture="Culture.vlandia" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zam_v2_h1" name="{=osa_ar_horse_armor_zam}Western Heavy Padded Mail Barding +1" mesh="AR_horse_armor_zam" culture="Culture.vlandia" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zam_v1_h2" name="{=osa_ar_horse_armor_zam}Western Heavy Padded Mail Barding +2" mesh="AR_horse_armor_zam" culture="Culture.vlandia" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zam_v2_h2" name="{=osa_ar_horse_armor_zam}Western Heavy Padded Mail Barding +2" mesh="AR_horse_armor_zam" culture="Culture.vlandia" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zam_v1_h3" name="{=osa_ar_horse_armor_zam}Western Heavy Padded Mail Barding +3" mesh="AR_horse_armor_zam" culture="Culture.vlandia" weight="30" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zam_v2_h3" name="{=osa_ar_horse_armor_zam}Western Heavy Padded Mail Barding +3" mesh="AR_horse_armor_zam" culture="Culture.vlandia" weight="30" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zan_v1_h0" name="{=osa_ar_horse_armor_zan}Western Padded Mail Barding" mesh="AR_horse_armor_zan" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zan_v2_h0" name="{=osa_ar_horse_armor_zan}Western Padded Mail Barding" mesh="AR_horse_armor_zan" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="29" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zan_v1_h1" name="{=osa_ar_horse_armor_zan}Western Padded Mail Barding +1" mesh="AR_horse_armor_zan" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zan_v2_h1" name="{=osa_ar_horse_armor_zan}Western Padded Mail Barding +1" mesh="AR_horse_armor_zan" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zan_v1_h2" name="{=osa_ar_horse_armor_zan}Western Padded Mail Barding +2" mesh="AR_horse_armor_zan" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zan_v2_h2" name="{=osa_ar_horse_armor_zan}Western Padded Mail Barding +2" mesh="AR_horse_armor_zan" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zan_v1_h3" name="{=osa_ar_horse_armor_zan}Western Padded Mail Barding +3" mesh="AR_horse_armor_zan" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zan_v2_h3" name="{=osa_ar_horse_armor_zan}Western Padded Mail Barding +3" mesh="AR_horse_armor_zan" culture="Culture.vlandia" weight="29" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_b_rein" charge_bonus="0" family_type="1" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zao_v1_h0" name="{=osa_ar_horse_armor_zao}Western Chainmail Barding" mesh="AR_horse_armor_zao" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zao_v2_h0" name="{=osa_ar_horse_armor_zao}Western Chainmail Barding" mesh="AR_horse_armor_zao" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" tail_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zao_v1_h1" name="{=osa_ar_horse_armor_zao}Western Chainmail Barding +1" mesh="AR_horse_armor_zao" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zao_v2_h1" name="{=osa_ar_horse_armor_zao}Western Chainmail Barding +1" mesh="AR_horse_armor_zao" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="37" mane_cover_type="all" tail_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zao_v1_h2" name="{=osa_ar_horse_armor_zao}Western Chainmail Barding +2" mesh="AR_horse_armor_zao" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zao_v2_h2" name="{=osa_ar_horse_armor_zao}Western Chainmail Barding +2" mesh="AR_horse_armor_zao" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="40" mane_cover_type="all" tail_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zao_v1_h3" name="{=osa_ar_horse_armor_zao}Western Chainmail Barding +3" mesh="AR_horse_armor_zao" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zao_v2_h3" name="{=osa_ar_horse_armor_zao}Western Chainmail Barding +3" mesh="AR_horse_armor_zao" culture="Culture.vlandia" weight="34" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="43" mane_cover_type="all" tail_cover_type="all" maneuver_bonus="0" speed_bonus="0" reins_mesh="horse_harness_vlandia_a_rein" charge_bonus="0" family_type="1" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zap_v1_h0" name="{=osa_ar_horse_armor_zap}Southern Half Plate and Cloth Barding" mesh="AR_horse_armor_zap" culture="Culture.aserai" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zap_v2_h0" name="{=osa_ar_horse_armor_zap}Southern Half Plate and Cloth Barding" mesh="AR_horse_armor_zap" culture="Culture.aserai" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zap_v1_h1" name="{=osa_ar_horse_armor_zap}Southern Half Plate and Cloth Barding +1" mesh="AR_horse_armor_zap" culture="Culture.aserai" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zap_v2_h1" name="{=osa_ar_horse_armor_zap}Southern Half Plate and Cloth Barding +1" mesh="AR_horse_armor_zap" culture="Culture.aserai" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="35" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zap_v1_h2" name="{=osa_ar_horse_armor_zap}Southern Half Plate and Cloth Barding +2" mesh="AR_horse_armor_zap" culture="Culture.aserai" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zap_v2_h2" name="{=osa_ar_horse_armor_zap}Southern Half Plate and Cloth Barding +2" mesh="AR_horse_armor_zap" culture="Culture.aserai" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="38" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zap_v1_h3" name="{=osa_ar_horse_armor_zap}Southern Half Plate and Cloth Barding +3" mesh="AR_horse_armor_zap" culture="Culture.aserai" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zap_v2_h3" name="{=osa_ar_horse_armor_zap}Southern Half Plate and Cloth Barding +3" mesh="AR_horse_armor_zap" culture="Culture.aserai" subtype="body_armor" weight="32" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zap2_v1_h0" name="{=osa_ar_horse_armor_zap2}Southern Plate and Cloth Barding" mesh="AR_horse_armor_zap2" culture="Culture.aserai" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zap2_v2_h0" name="{=osa_ar_horse_armor_zap2}Southern Plate and Cloth Barding" mesh="AR_horse_armor_zap2" culture="Culture.aserai" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zap2_v1_h1" name="{=osa_ar_horse_armor_zap2}Southern Plate and Cloth Barding +1" mesh="AR_horse_armor_zap2" culture="Culture.aserai" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zap2_v2_h1" name="{=osa_ar_horse_armor_zap2}Southern Plate and Cloth Barding +1" mesh="AR_horse_armor_zap2" culture="Culture.aserai" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zap2_v1_h2" name="{=osa_ar_horse_armor_zap2}Southern Plate and Cloth Barding +2" mesh="AR_horse_armor_zap2" culture="Culture.aserai" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zap2_v2_h2" name="{=osa_ar_horse_armor_zap2}Southern Plate and Cloth Barding +2" mesh="AR_horse_armor_zap2" culture="Culture.aserai" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="48" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zap2_v1_h3" name="{=osa_ar_horse_armor_zap2}Southern Plate and Cloth Barding +3" mesh="AR_horse_armor_zap2" culture="Culture.aserai" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zap2_v2_h3" name="{=osa_ar_horse_armor_zap2}Southern Plate and Cloth Barding +3" mesh="AR_horse_armor_zap2" culture="Culture.aserai" subtype="body_armor" weight="42" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="51" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaq_v1_h0" name="{=osa_ar_horse_armor_zaq}Southern Half Mail And Plate Barding" mesh="AR_horse_armor_zaq" culture="Culture.aserai" subtype="body_armor" weight="34" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaq_v2_h0" name="{=osa_ar_horse_armor_zaq}Southern Half Mail And Plate Barding" mesh="AR_horse_armor_zaq" culture="Culture.aserai" subtype="body_armor" weight="34" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaq_v1_h1" name="{=osa_ar_horse_armor_zaq}Southern Half Mail And Plate Barding +1" mesh="AR_horse_armor_zaq" culture="Culture.aserai" subtype="body_armor" weight="34" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaq_v2_h1" name="{=osa_ar_horse_armor_zaq}Southern Half Mail And Plate Barding +1" mesh="AR_horse_armor_zaq" culture="Culture.aserai" subtype="body_armor" weight="34" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="37" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaq_v1_h2" name="{=osa_ar_horse_armor_zaq}Southern Half Mail And Plate Barding +2" mesh="AR_horse_armor_zaq" culture="Culture.aserai" subtype="body_armor" weight="34" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaq_v2_h2" name="{=osa_ar_horse_armor_zaq}Southern Half Mail And Plate Barding +2" mesh="AR_horse_armor_zaq" culture="Culture.aserai" subtype="body_armor" weight="34" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="40" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaq_v1_h3" name="{=osa_ar_horse_armor_zaq}Southern Half Mail And Plate Barding +3" mesh="AR_horse_armor_zaq" culture="Culture.aserai" subtype="body_armor" weight="34" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaq_v2_h3" name="{=osa_ar_horse_armor_zaq}Southern Half Mail And Plate Barding +3" mesh="AR_horse_armor_zaq" culture="Culture.aserai" subtype="body_armor" weight="34" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="43" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaq2_v1_h0" name="{=osa_ar_horse_armor_zaq2}Southern Mail And Plate Barding" mesh="AR_horse_armor_zaq2" culture="Culture.aserai" subtype="body_armor" weight="44" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaq2_v2_h0" name="{=osa_ar_horse_armor_zaq2}Southern Mail And Plate Barding" mesh="AR_horse_armor_zaq2" culture="Culture.aserai" subtype="body_armor" weight="44" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaq2_v1_h1" name="{=osa_ar_horse_armor_zaq2}Southern Mail And Plate Barding +1" mesh="AR_horse_armor_zaq2" culture="Culture.aserai" subtype="body_armor" weight="44" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaq2_v2_h1" name="{=osa_ar_horse_armor_zaq2}Southern Mail And Plate Barding +1" mesh="AR_horse_armor_zaq2" culture="Culture.aserai" subtype="body_armor" weight="44" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="47" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaq2_v1_h2" name="{=osa_ar_horse_armor_zaq2}Southern Mail And Plate Barding +2" mesh="AR_horse_armor_zaq2" culture="Culture.aserai" subtype="body_armor" weight="44" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaq2_v2_h2" name="{=osa_ar_horse_armor_zaq2}Southern Mail And Plate Barding +2" mesh="AR_horse_armor_zaq2" culture="Culture.aserai" subtype="body_armor" weight="44" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="50" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zaq2_v1_h3" name="{=osa_ar_horse_armor_zaq2}Southern Mail And Plate Barding +3" mesh="AR_horse_armor_zaq2" culture="Culture.aserai" subtype="body_armor" weight="44" difficulty="0" appearance="0.4" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zaq2_v2_h3" name="{=osa_ar_horse_armor_zaq2}Southern Mail And Plate Barding +3" mesh="AR_horse_armor_zaq2" culture="Culture.aserai" subtype="body_armor" weight="44" difficulty="0" appearance="0.4" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="53" mane_cover_type="all" family_type="1" modifier_group="plate" reins_mesh="horse_harness_aserai_c_rein" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zar_v1_h0" name="{=osa_ar_horse_armor_zar}Western Cloth Barding" mesh="AR_horse_armor_zar" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zar_v2_h0" name="{=osa_ar_horse_armor_zar}Western Cloth Barding" mesh="AR_horse_armor_zar" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zar_v1_h1" name="{=osa_ar_horse_armor_zar}Western Cloth Barding +1" mesh="AR_horse_armor_zar" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zar_v2_h1" name="{=osa_ar_horse_armor_zar}Western Cloth Barding +1" mesh="AR_horse_armor_zar" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zar_v1_h2" name="{=osa_ar_horse_armor_zar}Western Cloth Barding +2" mesh="AR_horse_armor_zar" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zar_v2_h2" name="{=osa_ar_horse_armor_zar}Western Cloth Barding +2" mesh="AR_horse_armor_zar" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zar_v1_h3" name="{=osa_ar_horse_armor_zar}Western Cloth Barding +3" mesh="AR_horse_armor_zar" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zar_v2_h3" name="{=osa_ar_horse_armor_zar}Western Cloth Barding +3" mesh="AR_horse_armor_zar" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="26" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zas_v1_h0" name="{=osa_ar_horse_armor_zak}Western 3/4 Cloth Barding" mesh="AR_horse_armor_zas" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zas_v2_h0" name="{=osa_ar_horse_armor_zak}Western 3/4 Cloth Barding" mesh="AR_horse_armor_zas" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zas_v1_h1" name="{=osa_ar_horse_armor_zak}Western 3/4 Cloth Barding +1" mesh="AR_horse_armor_zas" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zas_v2_h1" name="{=osa_ar_horse_armor_zak}Western 3/4 Cloth Barding +1" mesh="AR_horse_armor_zas" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zas_v1_h2" name="{=osa_ar_horse_armor_zak}Western 3/4 Cloth Barding +2" mesh="AR_horse_armor_zas" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zas_v2_h2" name="{=osa_ar_horse_armor_zak}Western 3/4 Cloth Barding +2" mesh="AR_horse_armor_zas" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zas_v1_h3" name="{=osa_ar_horse_armor_zak}Western 3/4 Cloth Barding +3" mesh="AR_horse_armor_zas" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zas_v2_h3" name="{=osa_ar_horse_armor_zak}Western 3/4 Cloth Barding +3" mesh="AR_horse_armor_zas" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zat_v1_h0" name="{=osa_ar_horse_armor_zal}Western Quarter Cloth Barding" mesh="AR_horse_armor_zat" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zat_v2_h0" name="{=osa_ar_horse_armor_zal}Western Quarter Cloth Barding" mesh="AR_horse_armor_zat" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="11" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zat_v1_h1" name="{=osa_ar_horse_armor_zal}Western Quarter Cloth Barding +1" mesh="AR_horse_armor_zat" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zat_v2_h1" name="{=osa_ar_horse_armor_zal}Western Quarter Cloth Barding +1" mesh="AR_horse_armor_zat" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zat_v1_h2" name="{=osa_ar_horse_armor_zal}Western Quarter Cloth Barding +2" mesh="AR_horse_armor_zat" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zat_v2_h2" name="{=osa_ar_horse_armor_zal}Western Quarter Cloth Barding +2" mesh="AR_horse_armor_zat" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zat_v1_h3" name="{=osa_ar_horse_armor_zal}Western Quarter Cloth Barding +3" mesh="AR_horse_armor_zat" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zat_v2_h3" name="{=osa_ar_horse_armor_zal}Western Quarter Cloth Barding +3" mesh="AR_horse_armor_zat" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zau_v1_h0" name="{=osa_ar_horse_armor_zau}Western Half Cloth Barding" mesh="AR_horse_armor_zau" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zau_v2_h0" name="{=osa_ar_horse_armor_zau}Western Half Cloth Barding" mesh="AR_horse_armor_zau" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zau_v1_h1" name="{=osa_ar_horse_armor_zau}Western Half Cloth Barding +1" mesh="AR_horse_armor_zau" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zau_v2_h1" name="{=osa_ar_horse_armor_zau}Western Half Cloth Barding +1" mesh="AR_horse_armor_zau" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zau_v1_h2" name="{=osa_ar_horse_armor_zau}Western Half Cloth Barding +2" mesh="AR_horse_armor_zau" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zau_v2_h2" name="{=osa_ar_horse_armor_zau}Western Half Cloth Barding +2" mesh="AR_horse_armor_zau" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zau_v1_h3" name="{=osa_ar_horse_armor_zau}Western Half Cloth Barding +3" mesh="AR_horse_armor_zau" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zau_v2_h3" name="{=osa_ar_horse_armor_zau}Western Half Cloth Barding +3" mesh="AR_horse_armor_zau" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_za_v1_h0" name="{=osa_ar_horse_armor_za}Reinforced Studded Leather Barding" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="23" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_za_v2_h0" name="{=osa_ar_horse_armor_za}Reinforced Studded Leather Barding" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="23" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_za_v1_h1" name="{=osa_ar_horse_armor_za}Reinforced Studded Leather Barding +1" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="23" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_za_v2_h1" name="{=osa_ar_horse_armor_za}Reinforced Studded Leather Barding +1" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="23" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="26" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_za_v1_h2" name="{=osa_ar_horse_armor_za}Reinforced Studded Leather Barding +2" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="23" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_za_v2_h2" name="{=osa_ar_horse_armor_za}Reinforced Studded Leather Barding +2" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="23" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="29" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_za_v1_h3" name="{=osa_ar_horse_armor_za}Reinforced Studded Leather Barding +3" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="23" difficulty="0" appearance="0.6" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_za_v2_h3" name="{=osa_ar_horse_armor_za}Reinforced Studded Leather Barding +3" mesh="horse_harness_khuzait_c_clotest" culture="Culture.khuzait" subtype="body_armor" weight="23" difficulty="0" appearance="0.6" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="32" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_aserai_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zb_v1_h0" name="{=osa_ar_horse_armor_zb}Imperial Stripped Noble Harness" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="10" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zb_v2_h0" name="{=osa_ar_horse_armor_zb}Imperial Stripped Noble Harness" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="10" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="10" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zb_v1_h1" name="{=osa_ar_horse_armor_zb}Imperial Stripped Noble Harness +1" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="10" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zb_v2_h1" name="{=osa_ar_horse_armor_zb}Imperial Stripped Noble Harness +1" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="10" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="13" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zb_v1_h2" name="{=osa_ar_horse_armor_zb}Imperial Stripped Noble Harness +2" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="10" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zb_v2_h2" name="{=osa_ar_horse_armor_zb}Imperial Stripped Noble Harness +2" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="10" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="16" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zb_v1_h3" name="{=osa_ar_horse_armor_zb}Imperial Stripped Noble Harness +3" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="10" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zb_v2_h3" name="{=osa_ar_horse_armor_zb}Imperial Stripped Noble Harness +3" mesh="horse_harness_imperial_a_clotest" culture="Culture.empire" subtype="body_armor" weight="10" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="19" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zc_v1_h0" name="{=osa_ar_horse_armor_zc}Imperial Noble Harness" mesh="horse_harness_a_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zc_v2_h0" name="{=osa_ar_horse_armor_zc}Imperial Noble Harness" mesh="horse_harness_a_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zc_v1_h1" name="{=osa_ar_horse_armor_zc}Imperial Noble Harness +1" mesh="horse_harness_a_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zc_v2_h1" name="{=osa_ar_horse_armor_zc}Imperial Noble Harness +1" mesh="horse_harness_a_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zc_v1_h2" name="{=osa_ar_horse_armor_zc}Imperial Noble Harness +2" mesh="horse_harness_a_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zc_v2_h2" name="{=osa_ar_horse_armor_zc}Imperial Noble Harness +2" mesh="horse_harness_a_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zc_v1_h3" name="{=osa_ar_horse_armor_zc}Imperial Noble Harness +3" mesh="horse_harness_a_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zc_v2_h3" name="{=osa_ar_horse_armor_zc}Imperial Noble Harness +3" mesh="horse_harness_a_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_b_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zd_v1_h0" name="{=osa_ar_horse_armor_zd}Northern Plated Ring Barding" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="25" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zd_v2_h0" name="{=osa_ar_horse_armor_zd}Northern Plated Ring Barding" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="25" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="25" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zd_v1_h1" name="{=osa_ar_horse_armor_zd}Northern Plated Ring Barding +1" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="25" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zd_v2_h1" name="{=osa_ar_horse_armor_zd}Northern Plated Ring Barding +1" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="25" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="28" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zd_v1_h2" name="{=osa_ar_horse_armor_zd}Northern Plated Ring Barding +2" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="25" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zd_v2_h2" name="{=osa_ar_horse_armor_zd}Northern Plated Ring Barding +2" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="25" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="31" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zd_v1_h3" name="{=osa_ar_horse_armor_zd}Northern Plated Ring Barding +3" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="25" appearance="0.9" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zd_v2_h3" name="{=osa_ar_horse_armor_zd}Northern Plated Ring Barding +3" mesh="horse_harness_sturgia_a_clotest" culture="Culture.sturgia" weight="25" appearance="0.9" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_roman_b_new_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_ze_v1_h0" name="{=osa_ar_horse_armor_ze}Southern Heavy Harness" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_ze_v2_h0" name="{=osa_ar_horse_armor_ze}Southern Heavy Harness" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="1" modifier_group="cloth" reins_mesh="horse_harness_vlandia_b_rein" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_ze_v1_h1" name="{=osa_ar_horse_armor_ze}Southern Heavy Harness +1" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_ze_v2_h1" name="{=osa_ar_horse_armor_ze}Southern Heavy Harness +1" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" modifier_group="cloth" reins_mesh="horse_harness_vlandia_b_rein" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_ze_v1_h2" name="{=osa_ar_horse_armor_ze}Southern Heavy Harness +2" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_ze_v2_h2" name="{=osa_ar_horse_armor_ze}Southern Heavy Harness +2" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" modifier_group="cloth" reins_mesh="horse_harness_vlandia_b_rein" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_ze_v1_h3" name="{=osa_ar_horse_armor_ze}Southern Heavy Harness +3" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_ze_v2_h3" name="{=osa_ar_horse_armor_ze}Southern Heavy Harness +3" mesh="horse_harness_aserai_b_clotest" culture="Culture.aserai" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" modifier_group="cloth" reins_mesh="horse_harness_vlandia_b_rein" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zf_v1_h0" name="{=osa_ar_horse_armor_zf}Steppe Heavy Saddle" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zf_v2_h0" name="{=osa_ar_horse_armor_zf}Steppe Heavy Saddle" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zf_v1_h1" name="{=osa_ar_horse_armor_zf}Steppe Heavy Saddle +1" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zf_v2_h1" name="{=osa_ar_horse_armor_zf}Steppe Heavy Saddle +1" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zf_v1_h2" name="{=osa_ar_horse_armor_zf}Steppe Heavy Saddle +2" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zf_v2_h2" name="{=osa_ar_horse_armor_zf}Steppe Heavy Saddle +2" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zf_v1_h3" name="{=osa_ar_horse_armor_zf}Steppe Heavy Saddle +3" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zf_v2_h3" name="{=osa_ar_horse_armor_zf}Steppe Heavy Saddle +3" mesh="horse_harness_khuzait_b_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zg_v1_h0" name="{=osa_ar_horse_armor_zg}Imperial Light Harness" mesh="horse_harness_roman_b_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zg_v2_h0" name="{=osa_ar_horse_armor_zg}Imperial Light Harness" mesh="horse_harness_roman_b_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_a_new_rein" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zg_v1_h1" name="{=osa_ar_horse_armor_zg}Imperial Light Harness +1" mesh="horse_harness_roman_b_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zg_v2_h1" name="{=osa_ar_horse_armor_zg}Imperial Light Harness +1" mesh="horse_harness_roman_b_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_a_new_rein" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zg_v1_h2" name="{=osa_ar_horse_armor_zg}Imperial Light Harness +2" mesh="horse_harness_roman_b_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zg_v2_h2" name="{=osa_ar_horse_armor_zg}Imperial Light Harness +2" mesh="horse_harness_roman_b_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_a_new_rein" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zg_v1_h3" name="{=osa_ar_horse_armor_zg}Imperial Light Harness +3" mesh="horse_harness_roman_b_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zg_v2_h3" name="{=osa_ar_horse_armor_zg}Imperial Light Harness +3" mesh="horse_harness_roman_b_new" culture="Culture.empire" weight="9" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_a_new_rein" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zh_v1_h0" name="{=osa_ar_horse_armor_zh}Steppe Heavy Fur Harness" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zh_v2_h0" name="{=osa_ar_horse_armor_zh}Steppe Heavy Fur Harness" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="9" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zh_v1_h1" name="{=osa_ar_horse_armor_zh}Steppe Heavy Fur Harness +1" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zh_v2_h1" name="{=osa_ar_horse_armor_zh}Steppe Heavy Fur Harness +1" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zh_v1_h2" name="{=osa_ar_horse_armor_zh}Steppe Heavy Fur Harness +2" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zh_v2_h2" name="{=osa_ar_horse_armor_zh}Steppe Heavy Fur Harness +2" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zh_v1_h3" name="{=osa_ar_horse_armor_zh}Steppe Heavy Fur Harness +3" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zh_v2_h3" name="{=osa_ar_horse_armor_zh}Steppe Heavy Fur Harness +3" mesh="horse_harness_khuzait_a_clotest" culture="Culture.khuzait" subtype="body_armor" weight="9" difficulty="0" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_khuzait_c_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zi_v1_h0" name="{=osa_ar_horse_armor_zi}Northern Heavy Noble Harness" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zi_v2_h0" name="{=osa_ar_horse_armor_zi}Northern Heavy Noble Harness" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="10" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zi_v1_h1" name="{=osa_ar_horse_armor_zi}Northern Heavy Noble Harness +1" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zi_v2_h1" name="{=osa_ar_horse_armor_zi}Northern Heavy Noble Harness +1" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="13" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zi_v1_h2" name="{=osa_ar_horse_armor_zi}Northern Heavy Noble Harness +2" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zi_v2_h2" name="{=osa_ar_horse_armor_zi}Northern Heavy Noble Harness +2" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="16" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_ar_horse_armor_zi_v1_h3" name="{=osa_ar_horse_armor_zi}Northern Heavy Noble Harness +3" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
+  <Item id="crpg_ar_horse_armor_zi_v2_h3" name="{=osa_ar_horse_armor_zi}Northern Heavy Noble Harness +3" mesh="horse_harness_sturgia_b_clotest" culture="Culture.sturgia" weight="10" appearance="1" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="19" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_sturgia_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_a_v1_h0" name="{=osa_dz_horse_armor_a}Imperial Silvered Lamellar Barding" mesh="DZ_horse_armor_a" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_a_v2_h0" name="{=osa_dz_horse_armor_a}Imperial Silvered Lamellar Barding" mesh="DZ_horse_armor_a" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_a_v1_h1" name="{=osa_dz_horse_armor_a}Imperial Silvered Lamellar Barding +1" mesh="DZ_horse_armor_a" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_a_v2_h1" name="{=osa_dz_horse_armor_a}Imperial Silvered Lamellar Barding +1" mesh="DZ_horse_armor_a" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_a_v1_h2" name="{=osa_dz_horse_armor_a}Imperial Silvered Lamellar Barding +2" mesh="DZ_horse_armor_a" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_a_v2_h2" name="{=osa_dz_horse_armor_a}Imperial Silvered Lamellar Barding +2" mesh="DZ_horse_armor_a" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_a_v1_h3" name="{=osa_dz_horse_armor_a}Imperial Silvered Lamellar Barding +3" mesh="DZ_horse_armor_a" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_a_v2_h3" name="{=osa_dz_horse_armor_a}Imperial Silvered Lamellar Barding +3" mesh="DZ_horse_armor_a" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_b_v1_h0" name="{=osa_dz_horse_armor_b}Imperial Silvered 3/4 Lamellar Barding" mesh="DZ_horse_armor_b" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_b_v2_h0" name="{=osa_dz_horse_armor_b}Imperial Silvered 3/4 Lamellar Barding" mesh="DZ_horse_armor_b" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_b_v1_h1" name="{=osa_dz_horse_armor_b}Imperial Silvered 3/4 Lamellar Barding +1" mesh="DZ_horse_armor_b" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_b_v2_h1" name="{=osa_dz_horse_armor_b}Imperial Silvered 3/4 Lamellar Barding +1" mesh="DZ_horse_armor_b" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_b_v1_h2" name="{=osa_dz_horse_armor_b}Imperial Silvered 3/4 Lamellar Barding +2" mesh="DZ_horse_armor_b" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_b_v2_h2" name="{=osa_dz_horse_armor_b}Imperial Silvered 3/4 Lamellar Barding +2" mesh="DZ_horse_armor_b" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="47" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_b_v1_h3" name="{=osa_dz_horse_armor_b}Imperial Silvered 3/4 Lamellar Barding +3" mesh="DZ_horse_armor_b" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_b_v2_h3" name="{=osa_dz_horse_armor_b}Imperial Silvered 3/4 Lamellar Barding +3" mesh="DZ_horse_armor_b" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="50" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_c_v1_h0" name="{=osa_dz_horse_armor_c}Imperial Lamellar Barding" mesh="DZ_horse_armor_c" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_c_v2_h0" name="{=osa_dz_horse_armor_c}Imperial Lamellar Barding" mesh="DZ_horse_armor_c" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_c_v1_h1" name="{=osa_dz_horse_armor_c}Imperial Lamellar Barding +1" mesh="DZ_horse_armor_c" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_c_v2_h1" name="{=osa_dz_horse_armor_c}Imperial Lamellar Barding +1" mesh="DZ_horse_armor_c" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_c_v1_h2" name="{=osa_dz_horse_armor_c}Imperial Lamellar Barding +2" mesh="DZ_horse_armor_c" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_c_v2_h2" name="{=osa_dz_horse_armor_c}Imperial Lamellar Barding +2" mesh="DZ_horse_armor_c" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_c_v1_h3" name="{=osa_dz_horse_armor_c}Imperial Lamellar Barding +3" mesh="DZ_horse_armor_c" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_c_v2_h3" name="{=osa_dz_horse_armor_c}Imperial Lamellar Barding +3" mesh="DZ_horse_armor_c" culture="Culture.empire" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_d_v1_h0" name="{=osa_dz_horse_armor_d}Imperial 3/4 Lamellar Barding" mesh="DZ_horse_armor_d" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_d_v2_h0" name="{=osa_dz_horse_armor_d}Imperial 3/4 Lamellar Barding" mesh="DZ_horse_armor_d" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="41" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_d_v1_h1" name="{=osa_dz_horse_armor_d}Imperial 3/4 Lamellar Barding +1" mesh="DZ_horse_armor_d" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_d_v2_h1" name="{=osa_dz_horse_armor_d}Imperial 3/4 Lamellar Barding +1" mesh="DZ_horse_armor_d" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="44" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_d_v1_h2" name="{=osa_dz_horse_armor_d}Imperial 3/4 Lamellar Barding +2" mesh="DZ_horse_armor_d" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_d_v2_h2" name="{=osa_dz_horse_armor_d}Imperial 3/4 Lamellar Barding +2" mesh="DZ_horse_armor_d" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="47" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_d_v1_h3" name="{=osa_dz_horse_armor_d}Imperial 3/4 Lamellar Barding +3" mesh="DZ_horse_armor_d" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_d_v2_h3" name="{=osa_dz_horse_armor_d}Imperial 3/4 Lamellar Barding +3" mesh="DZ_horse_armor_d" culture="Culture.empire" subtype="body_armor" weight="41" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="50" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_e_v1_h0" name="{=osa_dz_horse_armor_e}Imperial Half Silvered Lamellar Barding" mesh="DZ_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_e_v2_h0" name="{=osa_dz_horse_armor_e}Imperial Half Silvered Lamellar Barding" mesh="DZ_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_a_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_e_v1_h1" name="{=osa_dz_horse_armor_e}Imperial Half Silvered Lamellar Barding +1" mesh="DZ_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_e_v2_h1" name="{=osa_dz_horse_armor_e}Imperial Half Silvered Lamellar Barding +1" mesh="DZ_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_a_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_e_v1_h2" name="{=osa_dz_horse_armor_e}Imperial Half Silvered Lamellar Barding +2" mesh="DZ_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_e_v2_h2" name="{=osa_dz_horse_armor_e}Imperial Half Silvered Lamellar Barding +2" mesh="DZ_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="42" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_a_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_e_v1_h3" name="{=osa_dz_horse_armor_e}Imperial Half Silvered Lamellar Barding +3" mesh="DZ_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_e_v2_h3" name="{=osa_dz_horse_armor_e}Imperial Half Silvered Lamellar Barding +3" mesh="DZ_horse_armor_e" culture="Culture.empire" subtype="body_armor" weight="36" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="45" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_a_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_f_v1_h0" name="{=osa_dz_horse_armor_f}Imperial Quarter Silvered Lamellar Barding" mesh="DZ_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_f_v2_h0" name="{=osa_dz_horse_armor_f}Imperial Quarter Silvered Lamellar Barding" mesh="DZ_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="31" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_f_v1_h1" name="{=osa_dz_horse_armor_f}Imperial Quarter Silvered Lamellar Barding +1" mesh="DZ_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_f_v2_h1" name="{=osa_dz_horse_armor_f}Imperial Quarter Silvered Lamellar Barding +1" mesh="DZ_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_f_v1_h2" name="{=osa_dz_horse_armor_f}Imperial Quarter Silvered Lamellar Barding +2" mesh="DZ_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_f_v2_h2" name="{=osa_dz_horse_armor_f}Imperial Quarter Silvered Lamellar Barding +2" mesh="DZ_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="37" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_f_v1_h3" name="{=osa_dz_horse_armor_f}Imperial Quarter Silvered Lamellar Barding +3" mesh="DZ_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_f_v2_h3" name="{=osa_dz_horse_armor_f}Imperial Quarter Silvered Lamellar Barding +3" mesh="DZ_horse_armor_f" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="40" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_g_v1_h0" name="{=osa_dz_horse_armor_g}Imperial Half Lamellar Barding" mesh="DZ_horse_armor_g" culture="Culture.empire" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_g_v2_h0" name="{=osa_dz_horse_armor_g}Imperial Half Lamellar Barding" mesh="DZ_horse_armor_g" culture="Culture.empire" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_a_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_g_v1_h1" name="{=osa_dz_horse_armor_g}Imperial Half Lamellar Barding +1" mesh="DZ_horse_armor_g" culture="Culture.empire" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_g_v2_h1" name="{=osa_dz_horse_armor_g}Imperial Half Lamellar Barding +1" mesh="DZ_horse_armor_g" culture="Culture.empire" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="37" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_a_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_g_v1_h2" name="{=osa_dz_horse_armor_g}Imperial Half Lamellar Barding +2" mesh="DZ_horse_armor_g" culture="Culture.empire" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_g_v2_h2" name="{=osa_dz_horse_armor_g}Imperial Half Lamellar Barding +2" mesh="DZ_horse_armor_g" culture="Culture.empire" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="40" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_a_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_g_v1_h3" name="{=osa_dz_horse_armor_g}Imperial Half Lamellar Barding +3" mesh="DZ_horse_armor_g" culture="Culture.empire" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_g_v2_h3" name="{=osa_dz_horse_armor_g}Imperial Half Lamellar Barding +3" mesh="DZ_horse_armor_g" culture="Culture.empire" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="43" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_imperial_a_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_h_v1_h0" name="{=osa_dz_horse_armor_h}Imperial Quarter Lamellar Barding" mesh="DZ_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_h_v2_h0" name="{=osa_dz_horse_armor_h}Imperial Quarter Lamellar Barding" mesh="DZ_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="31" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_h_v1_h1" name="{=osa_dz_horse_armor_h}Imperial Quarter Lamellar Barding +1" mesh="DZ_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_h_v2_h1" name="{=osa_dz_horse_armor_h}Imperial Quarter Lamellar Barding +1" mesh="DZ_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_h_v1_h2" name="{=osa_dz_horse_armor_h}Imperial Quarter Lamellar Barding +2" mesh="DZ_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_h_v2_h2" name="{=osa_dz_horse_armor_h}Imperial Quarter Lamellar Barding +2" mesh="DZ_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="37" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_dz_horse_armor_h_v1_h3" name="{=osa_dz_horse_armor_h}Imperial Quarter Lamellar Barding +3" mesh="DZ_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_dz_horse_armor_h_v2_h3" name="{=osa_dz_horse_armor_h}Imperial Quarter Lamellar Barding +3" mesh="DZ_horse_armor_h" culture="Culture.empire" subtype="body_armor" weight="31" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="40" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_roman_b_new_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a_v1_h0" name="{=osa_tv_horse_armor_a}Western Steel Scale Barding" mesh="TV_horse_armor_a" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a_v2_h0" name="{=osa_tv_horse_armor_a}Western Steel Scale Barding" mesh="TV_horse_armor_a" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a_v1_h1" name="{=osa_tv_horse_armor_a}Western Steel Scale Barding +1" mesh="TV_horse_armor_a" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a_v2_h1" name="{=osa_tv_horse_armor_a}Western Steel Scale Barding +1" mesh="TV_horse_armor_a" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a_v1_h2" name="{=osa_tv_horse_armor_a}Western Steel Scale Barding +2" mesh="TV_horse_armor_a" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a_v2_h2" name="{=osa_tv_horse_armor_a}Western Steel Scale Barding +2" mesh="TV_horse_armor_a" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a_v1_h3" name="{=osa_tv_horse_armor_a}Western Steel Scale Barding +3" mesh="TV_horse_armor_a" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a_v2_h3" name="{=osa_tv_horse_armor_a}Western Steel Scale Barding +3" mesh="TV_horse_armor_a" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a2_v1_h0" name="{=osa_tv_horse_armor_a2}Western Lamellar Barding" mesh="TV_horse_armor_a2" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a2_v2_h0" name="{=osa_tv_horse_armor_a2}Western Lamellar Barding" mesh="TV_horse_armor_a2" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a2_v1_h1" name="{=osa_tv_horse_armor_a2}Western Lamellar Barding +1" mesh="TV_horse_armor_a2" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a2_v2_h1" name="{=osa_tv_horse_armor_a2}Western Lamellar Barding +1" mesh="TV_horse_armor_a2" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a2_v1_h2" name="{=osa_tv_horse_armor_a2}Western Lamellar Barding +2" mesh="TV_horse_armor_a2" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a2_v2_h2" name="{=osa_tv_horse_armor_a2}Western Lamellar Barding +2" mesh="TV_horse_armor_a2" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="52" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a2_v1_h3" name="{=osa_tv_horse_armor_a2}Western Lamellar Barding +3" mesh="TV_horse_armor_a2" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a2_v2_h3" name="{=osa_tv_horse_armor_a2}Western Lamellar Barding +3" mesh="TV_horse_armor_a2" culture="Culture.vlandia" subtype="body_armor" weight="46" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="55" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a3_v1_h0" name="{=osa_tv_horse_armor_a3}Western Padded Barding, Diamonds" mesh="TV_horse_armor_a3" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a3_v2_h0" name="{=osa_tv_horse_armor_a3}Western Padded Barding, Diamonds" mesh="TV_horse_armor_a3" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a3_v1_h1" name="{=osa_tv_horse_armor_a3}Western Padded Barding, Diamonds +1" mesh="TV_horse_armor_a3" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a3_v2_h1" name="{=osa_tv_horse_armor_a3}Western Padded Barding, Diamonds +1" mesh="TV_horse_armor_a3" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a3_v1_h2" name="{=osa_tv_horse_armor_a3}Western Padded Barding, Diamonds +2" mesh="TV_horse_armor_a3" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a3_v2_h2" name="{=osa_tv_horse_armor_a3}Western Padded Barding, Diamonds +2" mesh="TV_horse_armor_a3" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="23" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_a3_v1_h3" name="{=osa_tv_horse_armor_a3}Western Padded Barding, Diamonds +3" mesh="TV_horse_armor_a3" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_a3_v2_h3" name="{=osa_tv_horse_armor_a3}Western Padded Barding, Diamonds +3" mesh="TV_horse_armor_a3" culture="Culture.vlandia" subtype="body_armor" weight="17" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="26" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_e_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b_v1_h0" name="{=osa_tv_horse_armor_b}Western 3/4 Steel Scale Barding" mesh="TV_horse_armor_b" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b_v2_h0" name="{=osa_tv_horse_armor_b}Western 3/4 Steel Scale Barding" mesh="TV_horse_armor_b" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="40" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b_v1_h1" name="{=osa_tv_horse_armor_b}Western 3/4 Steel Scale Barding +1" mesh="TV_horse_armor_b" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b_v2_h1" name="{=osa_tv_horse_armor_b}Western 3/4 Steel Scale Barding +1" mesh="TV_horse_armor_b" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="43" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b_v1_h2" name="{=osa_tv_horse_armor_b}Western 3/4 Steel Scale Barding +2" mesh="TV_horse_armor_b" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b_v2_h2" name="{=osa_tv_horse_armor_b}Western 3/4 Steel Scale Barding +2" mesh="TV_horse_armor_b" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b_v1_h3" name="{=osa_tv_horse_armor_b}Western 3/4 Steel Scale Barding +3" mesh="TV_horse_armor_b" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b_v2_h3" name="{=osa_tv_horse_armor_b}Western 3/4 Steel Scale Barding +3" mesh="TV_horse_armor_b" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b2_v1_h0" name="{=osa_tv_horse_armor_b2}Western 3/4 Lamellar Barding" mesh="TV_horse_armor_b2" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b2_v2_h0" name="{=osa_tv_horse_armor_b2}Western 3/4 Lamellar Barding" mesh="TV_horse_armor_b2" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="40" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b2_v1_h1" name="{=osa_tv_horse_armor_b2}Western 3/4 Lamellar Barding +1" mesh="TV_horse_armor_b2" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b2_v2_h1" name="{=osa_tv_horse_armor_b2}Western 3/4 Lamellar Barding +1" mesh="TV_horse_armor_b2" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="43" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b2_v1_h2" name="{=osa_tv_horse_armor_b2}Western 3/4 Lamellar Barding +2" mesh="TV_horse_armor_b2" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b2_v2_h2" name="{=osa_tv_horse_armor_b2}Western 3/4 Lamellar Barding +2" mesh="TV_horse_armor_b2" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="46" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b2_v1_h3" name="{=osa_tv_horse_armor_b2}Western 3/4 Lamellar Barding +3" mesh="TV_horse_armor_b2" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b2_v2_h3" name="{=osa_tv_horse_armor_b2}Western 3/4 Lamellar Barding +3" mesh="TV_horse_armor_b2" culture="Culture.vlandia" subtype="body_armor" weight="40" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="49" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b3_v1_h0" name="{=osa_tv_horse_armor_b3}Western 3/4 Padded Barding, Diamonds" mesh="TV_horse_armor_b3" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b3_v2_h0" name="{=osa_tv_horse_armor_b3}Western 3/4 Padded Barding, Diamonds" mesh="TV_horse_armor_b3" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b3_v1_h1" name="{=osa_tv_horse_armor_b3}Western 3/4 Padded Barding, Diamonds +1" mesh="TV_horse_armor_b3" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b3_v2_h1" name="{=osa_tv_horse_armor_b3}Western 3/4 Padded Barding, Diamonds +1" mesh="TV_horse_armor_b3" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b3_v1_h2" name="{=osa_tv_horse_armor_b3}Western 3/4 Padded Barding, Diamonds +2" mesh="TV_horse_armor_b3" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b3_v2_h2" name="{=osa_tv_horse_armor_b3}Western 3/4 Padded Barding, Diamonds +2" mesh="TV_horse_armor_b3" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_b3_v1_h3" name="{=osa_tv_horse_armor_b3}Western 3/4 Padded Barding, Diamonds +3" mesh="TV_horse_armor_b3" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_b3_v2_h3" name="{=osa_tv_horse_armor_b3}Western 3/4 Padded Barding, Diamonds +3" mesh="TV_horse_armor_b3" culture="Culture.vlandia" subtype="body_armor" weight="15" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="24" mane_cover_type="none" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c_v1_h0" name="{=osa_tv_horse_armor_c}Western Quarter Steel Scale Barding" mesh="TV_horse_armor_c" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c_v2_h0" name="{=osa_tv_horse_armor_c}Western Quarter Steel Scale Barding" mesh="TV_horse_armor_c" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c_v1_h1" name="{=osa_tv_horse_armor_c}Western Quarter Steel Scale Barding +1" mesh="TV_horse_armor_c" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c_v2_h1" name="{=osa_tv_horse_armor_c}Western Quarter Steel Scale Barding +1" mesh="TV_horse_armor_c" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c_v1_h2" name="{=osa_tv_horse_armor_c}Western Quarter Steel Scale Barding +2" mesh="TV_horse_armor_c" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c_v2_h2" name="{=osa_tv_horse_armor_c}Western Quarter Steel Scale Barding +2" mesh="TV_horse_armor_c" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c_v1_h3" name="{=osa_tv_horse_armor_c}Western Quarter Steel Scale Barding +3" mesh="TV_horse_armor_c" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c_v2_h3" name="{=osa_tv_horse_armor_c}Western Quarter Steel Scale Barding +3" mesh="TV_horse_armor_c" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c2_v1_h0" name="{=osa_tv_horse_armor_c2}Western Quarter Lamellar Barding" mesh="TV_horse_armor_c2" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c2_v2_h0" name="{=osa_tv_horse_armor_c2}Western Quarter Lamellar Barding" mesh="TV_horse_armor_c2" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c2_v1_h1" name="{=osa_tv_horse_armor_c2}Western Quarter Lamellar Barding +1" mesh="TV_horse_armor_c2" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c2_v2_h1" name="{=osa_tv_horse_armor_c2}Western Quarter Lamellar Barding +1" mesh="TV_horse_armor_c2" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c2_v1_h2" name="{=osa_tv_horse_armor_c2}Western Quarter Lamellar Barding +2" mesh="TV_horse_armor_c2" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c2_v2_h2" name="{=osa_tv_horse_armor_c2}Western Quarter Lamellar Barding +2" mesh="TV_horse_armor_c2" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c2_v1_h3" name="{=osa_tv_horse_armor_c2}Western Quarter Lamellar Barding +3" mesh="TV_horse_armor_c2" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c2_v2_h3" name="{=osa_tv_horse_armor_c2}Western Quarter Lamellar Barding +3" mesh="TV_horse_armor_c2" culture="Culture.vlandia" subtype="body_armor" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c3_v1_h0" name="{=osa_tv_horse_armor_c3}Western Quarter Padded Barding, Diamonds" mesh="TV_horse_armor_c3" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c3_v2_h0" name="{=osa_tv_horse_armor_c3}Western Quarter Padded Barding, Diamonds" mesh="TV_horse_armor_c3" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="11" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c3_v1_h1" name="{=osa_tv_horse_armor_c3}Western Quarter Padded Barding, Diamonds +1" mesh="TV_horse_armor_c3" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c3_v2_h1" name="{=osa_tv_horse_armor_c3}Western Quarter Padded Barding, Diamonds +1" mesh="TV_horse_armor_c3" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="14" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c3_v1_h2" name="{=osa_tv_horse_armor_c3}Western Quarter Padded Barding, Diamonds +2" mesh="TV_horse_armor_c3" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c3_v2_h2" name="{=osa_tv_horse_armor_c3}Western Quarter Padded Barding, Diamonds +2" mesh="TV_horse_armor_c3" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="17" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_c3_v1_h3" name="{=osa_tv_horse_armor_c3}Western Quarter Padded Barding, Diamonds +3" mesh="TV_horse_armor_c3" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_c3_v2_h3" name="{=osa_tv_horse_armor_c3}Western Quarter Padded Barding, Diamonds +3" mesh="TV_horse_armor_c3" culture="Culture.vlandia" subtype="body_armor" weight="11" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="20" mane_cover_type="all" family_type="1" reins_mesh="horse_harness_vlandia_b_rein" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d_v1_h0" name="{=osa_tv_horse_armor_d}Western Half Steel Scale Barding" mesh="TV_horse_armor_d" culture="Culture.vlandia" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d_v2_h0" name="{=osa_tv_horse_armor_d}Western Half Steel Scale Barding" mesh="TV_horse_armor_d" culture="Culture.vlandia" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="34" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d_v1_h1" name="{=osa_tv_horse_armor_d}Western Half Steel Scale Barding +1" mesh="TV_horse_armor_d" culture="Culture.vlandia" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d_v2_h1" name="{=osa_tv_horse_armor_d}Western Half Steel Scale Barding +1" mesh="TV_horse_armor_d" culture="Culture.vlandia" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="37" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d_v1_h2" name="{=osa_tv_horse_armor_d}Western Half Steel Scale Barding +2" mesh="TV_horse_armor_d" culture="Culture.vlandia" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d_v2_h2" name="{=osa_tv_horse_armor_d}Western Half Steel Scale Barding +2" mesh="TV_horse_armor_d" culture="Culture.vlandia" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="40" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d_v1_h3" name="{=osa_tv_horse_armor_d}Western Half Steel Scale Barding +3" mesh="TV_horse_armor_d" culture="Culture.vlandia" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d_v2_h3" name="{=osa_tv_horse_armor_d}Western Half Steel Scale Barding +3" mesh="TV_horse_armor_d" culture="Culture.vlandia" subtype="body_armor" weight="34" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="43" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d2_v1_h0" name="{=osa_tv_horse_armor_d2}Western Half Lamellar Barding" mesh="TV_horse_armor_d2" subtype="body_armor" culture="Culture.vlandia" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d2_v2_h0" name="{=osa_tv_horse_armor_d2}Western Half Lamellar Barding" mesh="TV_horse_armor_d2" subtype="body_armor" culture="Culture.vlandia" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="30" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d2_v1_h1" name="{=osa_tv_horse_armor_d2}Western Half Lamellar Barding +1" mesh="TV_horse_armor_d2" subtype="body_armor" culture="Culture.vlandia" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d2_v2_h1" name="{=osa_tv_horse_armor_d2}Western Half Lamellar Barding +1" mesh="TV_horse_armor_d2" subtype="body_armor" culture="Culture.vlandia" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="33" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d2_v1_h2" name="{=osa_tv_horse_armor_d2}Western Half Lamellar Barding +2" mesh="TV_horse_armor_d2" subtype="body_armor" culture="Culture.vlandia" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d2_v2_h2" name="{=osa_tv_horse_armor_d2}Western Half Lamellar Barding +2" mesh="TV_horse_armor_d2" subtype="body_armor" culture="Culture.vlandia" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="36" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d2_v1_h3" name="{=osa_tv_horse_armor_d2}Western Half Lamellar Barding +3" mesh="TV_horse_armor_d2" subtype="body_armor" culture="Culture.vlandia" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d2_v2_h3" name="{=osa_tv_horse_armor_d2}Western Half Lamellar Barding +3" mesh="TV_horse_armor_d2" subtype="body_armor" culture="Culture.vlandia" weight="30" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="39" mane_cover_type="all" family_type="1" modifier_group="chain" reins_mesh="horse_harness_imperial_a_rein" material_type="Chainmail" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d3_v1_h0" name="{=osa_tv_horse_armor_d3}Western Half Padded Barding, Diamonds" mesh="TV_horse_armor_d3" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d3_v2_h0" name="{=osa_tv_horse_armor_d3}Western Half Padded Barding, Diamonds" mesh="TV_horse_armor_d3" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="12" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d3_v1_h1" name="{=osa_tv_horse_armor_d3}Western Half Padded Barding, Diamonds +1" mesh="TV_horse_armor_d3" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d3_v2_h1" name="{=osa_tv_horse_armor_d3}Western Half Padded Barding, Diamonds +1" mesh="TV_horse_armor_d3" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="15" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d3_v1_h2" name="{=osa_tv_horse_armor_d3}Western Half Padded Barding, Diamonds +2" mesh="TV_horse_armor_d3" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d3_v2_h2" name="{=osa_tv_horse_armor_d3}Western Half Padded Barding, Diamonds +2" mesh="TV_horse_armor_d3" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="18" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
-  <Item id="crpg_tv_horse_armor_d3_v1_h3" name="{=osa_tv_horse_armor_d3}Western Half Padded Barding, Diamonds +3" mesh="TV_horse_armor_d3" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
+  <Item id="crpg_tv_horse_armor_d3_v2_h3" name="{=osa_tv_horse_armor_d3}Western Half Padded Barding, Diamonds +3" mesh="TV_horse_armor_d3" culture="Culture.vlandia" subtype="body_armor" weight="12" difficulty="0" appearance="0.5" Type="HorseHarness">
     <ItemComponent>
       <Armor body_armor="21" mane_cover_type="all" family_type="1" modifier_group="leather" reins_mesh="horse_harness_imperial_a_rein" material_type="Leather" />
     </ItemComponent>


### PR DESCRIPTION
Saddle Horse line -15% speed
All other mounts -10% speed
All mounts +2 maneuver
Disables Shadowfax

Significantly slows down cavalry, especially the Saddle Horse line, leaving the new top speed at 51 instead of 68. Mounts given some maneuver back to compensate, but not enough to match the inflated >T10. To be paired with lance angle widening