### PR TITLE
Initial balance of single stage reload paddlebutt carbine

### DIFF
--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -14848,7 +14848,7 @@
       <Piece id="crpg_nagamaki_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <Item id="crpg_wheellock_h0" name="{=BalanceMe}Wheellock" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_wheellock_h0" name="{=AppleTruce}Wheellock Carbine" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="108" accuracy="97" thrust_damage="44" thrust_speed="84" speed_rating="68" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
@@ -14856,7 +14856,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_wheellock_h1" name="{=BalanceMe}Wheellock +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_wheellock_h1" name="{=AppleTruce}Wheellock Carbine +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="108" accuracy="98" thrust_damage="45" thrust_speed="85" speed_rating="70" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
@@ -14864,7 +14864,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_wheellock_h2" name="{=BalanceMe}Wheellock +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_wheellock_h2" name="{=AppleTruce}Wheellock Carbine +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="109" accuracy="99" thrust_damage="46" thrust_speed="86" speed_rating="72" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
@@ -14872,7 +14872,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_wheellock_h3" name="{=BalanceMe}Wheellock +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_wheellock_h3" name="{=AppleTruce}Wheellock Carbine +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="110" accuracy="100" thrust_damage="47" thrust_speed="87" speed_rating="73" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -14848,4 +14848,36 @@
       <Piece id="crpg_nagamaki_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
+  <Item id="crpg_wheellock_h0" name="{=BalanceMe}Wheellock" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="108" accuracy="97" thrust_damage="44" thrust_speed="84" speed_rating="68" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_wheellock_h1" name="{=BalanceMe}Wheellock +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="108" accuracy="98" thrust_damage="45" thrust_speed="85" speed_rating="70" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_wheellock_h2" name="{=BalanceMe}Wheellock +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="109" accuracy="99" thrust_damage="46" thrust_speed="86" speed_rating="72" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_wheellock_h3" name="{=BalanceMe}Wheellock +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="110" accuracy="100" thrust_damage="47" thrust_speed="87" speed_rating="73" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="cla_musket" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
 </Items>


### PR DESCRIPTION
In case I do not complete the two stage reload for guns before next patch, here is wheellock balanced for current fireamr useage sets. Making new PR was easier for me than rebasing Meows PR620.  It is effectively a copy of Windlass knights xbow, with slightly boosted missle speed and damage at the cost of accuracy and reload speed, It has same reload speed as the xbow, but firearm reload is lsower.