### PR TITLE
Polearm & mace budget

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -5043,7 +5043,7 @@
   <CraftingPiece id="crpg_bludgeon_staff_blade_h0" name="{=kaikaikai}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.45">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Blunt" damage_factor="1.4" />
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -5055,7 +5055,7 @@
   <CraftingPiece id="crpg_bludgeon_staff_blade_h1" name="{=kaikaikai}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.45">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Blunt" damage_factor="1.4" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -5067,7 +5067,7 @@
   <CraftingPiece id="crpg_bludgeon_staff_blade_h2" name="{=kaikaikai}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.42">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Blunt" damage_factor="1.6" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -5079,7 +5079,7 @@
   <CraftingPiece id="crpg_bludgeon_staff_blade_h3" name="{=kaikaikai}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.36">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Blunt" damage_factor="1.6" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -6123,7 +6123,7 @@
   <CraftingPiece id="crpg_glaive_blade_h0" name="{=kaikaikai}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.66">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -6132,7 +6132,7 @@
   <CraftingPiece id="crpg_glaive_blade_h1" name="{=kaikaikai}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.63">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -6141,16 +6141,16 @@
   <CraftingPiece id="crpg_glaive_blade_h2" name="{=kaikaikai}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.63">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.8" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_glaive_blade_h3" name="{=kaikaikai}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.63">
+  <CraftingPiece id="crpg_glaive_blade_h3" name="{=kaikaikai}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.58">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.8" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -6159,7 +6159,7 @@
   <CraftingPiece id="crpg_fine_steel_menavlion_blade_h0" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.57">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -6168,7 +6168,7 @@
   <CraftingPiece id="crpg_fine_steel_menavlion_blade_h1" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.57">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -6177,7 +6177,7 @@
   <CraftingPiece id="crpg_fine_steel_menavlion_blade_h2" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.54">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.9" />
+      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -6186,7 +6186,7 @@
   <CraftingPiece id="crpg_fine_steel_menavlion_blade_h3" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.51">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.9" />
+      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -6228,7 +6228,7 @@
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6242,7 +6242,7 @@
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6256,7 +6256,7 @@
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6270,7 +6270,7 @@
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -7164,7 +7164,7 @@
   <CraftingPiece id="crpg_fine_steel_leaf_spear_blade_h1" name="{=9aYBy1RN}Fine Steel Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1456">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="1.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -7173,7 +7173,7 @@
   <CraftingPiece id="crpg_fine_steel_leaf_spear_blade_h2" name="{=9aYBy1RN}Fine Steel Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1456">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="1.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -7182,7 +7182,7 @@
   <CraftingPiece id="crpg_fine_steel_leaf_spear_blade_h3" name="{=9aYBy1RN}Fine Steel Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1456">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="1.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -7842,7 +7842,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_billhook_blade_h0" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.52" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -7854,7 +7854,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_billhook_blade_h1" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.50" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -7866,7 +7866,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_billhook_blade_h2" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.48" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -7878,7 +7878,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_billhook_blade_h3" name="{=Yeldur}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.48" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="5.0" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -9880,7 +9880,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="4.9" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -9894,7 +9894,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="5.0" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -9908,7 +9908,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="5.0" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -9922,7 +9922,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="5.2" />
+      <Swing damage_type="Cut" damage_factor="4.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -24996,7 +24996,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_awlpike_blade_h0" name="{=}Awlpike Blade" tier="4" piece_type="Blade" mesh="awlpike_blade" length="85.8" weight="0.45">
+  <CraftingPiece id="crpg_awlpike_blade_h0" name="{=}Awlpike Blade" tier="4" piece_type="Blade" mesh="awlpike_blade" length="85.8" weight="0.5">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
       <Swing damage_type="Blunt" damage_factor="2.0" />
@@ -25009,7 +25009,7 @@
       <Flag name="CanHook" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_awlpike_blade_h1" name="{=}Awlpike Blade" tier="4" piece_type="Blade" mesh="awlpike_blade" length="85.8" weight="0.4">
+  <CraftingPiece id="crpg_awlpike_blade_h1" name="{=}Awlpike Blade" tier="4" piece_type="Blade" mesh="awlpike_blade" length="85.8" weight="0.45">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
       <Swing damage_type="Blunt" damage_factor="2.0" />
@@ -25022,7 +25022,7 @@
       <Flag name="CanHook" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_awlpike_blade_h2" name="{=}Awlpike Blade" tier="4" piece_type="Blade" mesh="awlpike_blade" length="85.8" weight="0.4">
+  <CraftingPiece id="crpg_awlpike_blade_h2" name="{=}Awlpike Blade" tier="4" piece_type="Blade" mesh="awlpike_blade" length="85.8" weight="0.45">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.9" />
       <Swing damage_type="Blunt" damage_factor="2.1" />
@@ -25035,7 +25035,7 @@
       <Flag name="CanHook" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_awlpike_blade_h3" name="{=}Awlpike Blade" tier="4" piece_type="Blade" mesh="awlpike_blade" length="85.8" weight="0.35">
+  <CraftingPiece id="crpg_awlpike_blade_h3" name="{=}Awlpike Blade" tier="4" piece_type="Blade" mesh="awlpike_blade" length="85.8" weight="0.4">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.9" />
       <Swing damage_type="Blunt" damage_factor="2.1" />
@@ -25928,11 +25928,24 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_great_long_maul_blade_h0" name="{=}Great Long Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.1" full_scale="true" excluded_item_usage_features="">
+  <CraftingPiece id="crpg_great_long_maul_blade_h0" name="{=}Great Long Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.1" full_scale="true" excluded_item_usage_features="shield:thrust">
+    <BuildData piece_offset="-11.0" next_piece_offset="0" />
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
+      <Swing damage_type="Blunt" damage_factor="2.5" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+      <Flag name="CanKnockDown" />
+      <Flag name="CanCrushThrough" />
+    </Flags>
+    <Materials>
+      <Material id="Iron2" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_great_long_maul_blade_h1" name="{=}Great Long Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.1" full_scale="true" excluded_item_usage_features="shield:thrust">
     <BuildData piece_offset="-11.0" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.6" />
-      <Thrust damage_type="Blunt" damage_factor="1.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -25943,11 +25956,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_great_long_maul_blade_h1" name="{=}Great Long Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.1" full_scale="true" excluded_item_usage_features="">
+  <CraftingPiece id="crpg_great_long_maul_blade_h2" name="{=}Great Long Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.1" full_scale="true" excluded_item_usage_features="shield:thrust">
     <BuildData piece_offset="-11.0" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.7" />
-      <Thrust damage_type="Blunt" damage_factor="1.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -25958,26 +25970,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_great_long_maul_blade_h2" name="{=}Great Long Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.1" full_scale="true" excluded_item_usage_features="">
+  <CraftingPiece id="crpg_great_long_maul_blade_h3" name="{=}Great Long Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.0" full_scale="true" excluded_item_usage_features="shield:thrust">
     <BuildData piece_offset="-11.0" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
-      <Thrust damage_type="Blunt" damage_factor="1.2" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
-      <Flag name="CanCrushThrough" />
-    </Flags>
-    <Materials>
-      <Material id="Iron2" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_great_long_maul_blade_h3" name="{=}Great Long Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.0" full_scale="true" excluded_item_usage_features="">
-    <BuildData piece_offset="-11.0" next_piece_offset="0" />
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
-      <Thrust damage_type="Blunt" damage_factor="1.2" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -26202,8 +26198,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_claymore_pole_blade_h0" name="{=}Claymore Blade" tier="4" piece_type="Blade" mesh="claymore_blade" culture="Culture.battania" length="111" weight="0.78">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -26211,8 +26207,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_claymore_pole_blade_h1" name="{=}Claymore Blade" tier="4" piece_type="Blade" mesh="claymore_blade" culture="Culture.battania" length="111" weight="0.78">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -26220,8 +26216,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_claymore_pole_blade_h2" name="{=}Claymore Blade" tier="4" piece_type="Blade" mesh="claymore_blade" culture="Culture.battania" length="111" weight="0.78">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Cut" damage_factor="4.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -26229,8 +26225,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_claymore_pole_blade_h3" name="{=}Claymore Blade" tier="4" piece_type="Blade" mesh="claymore_blade" culture="Culture.battania" length="111" weight="0.67">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Cut" damage_factor="4.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -26596,7 +26592,19 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_blade_h0" name="{=kaikaikai}French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.01">
+  <CraftingPiece id="crpg_french_voulge_blade_h0" name="{=kaikaikai}French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.5">
+    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_french_voulge_blade_h1" name="{=kaikaikai}French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.5">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.5" />
@@ -26608,7 +26616,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_blade_h1" name="{=kaikaikai}French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.01">
+  <CraftingPiece id="crpg_french_voulge_blade_h2" name="{=kaikaikai}French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.5">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.7" />
@@ -26620,10 +26628,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_blade_h2" name="{=kaikaikai}French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.01">
+  <CraftingPiece id="crpg_french_voulge_blade_h3" name="{=kaikaikai}French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.45">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26632,37 +26640,25 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_blade_h3" name="{=kaikaikai}French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.01">
-    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.9" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_handle_h0" name="Polearm Shaft with Langets" tier="2" piece_type="Handle" mesh="french_voulge_shaft" length="130" weight="3.1" CraftingCost="120">
+  <CraftingPiece id="crpg_french_voulge_handle_h0" name="Polearm Shaft with Langets" tier="2" piece_type="Handle" mesh="french_voulge_shaft" length="130" weight="1.5" CraftingCost="120">
     <BuildData previous_piece_offset="0" next_piece_offset="0" piece_offset="30" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_handle_h1" name="Polearm Shaft with Langets" tier="2" piece_type="Handle" mesh="french_voulge_shaft" length="130" weight="3.1" CraftingCost="120">
+  <CraftingPiece id="crpg_french_voulge_handle_h1" name="Polearm Shaft with Langets" tier="2" piece_type="Handle" mesh="french_voulge_shaft" length="130" weight="1.5" CraftingCost="120">
     <BuildData previous_piece_offset="0" next_piece_offset="0" piece_offset="30" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_handle_h2" name="Polearm Shaft with Langets" tier="2" piece_type="Handle" mesh="french_voulge_shaft" length="130" weight="3.1" CraftingCost="120">
+  <CraftingPiece id="crpg_french_voulge_handle_h2" name="Polearm Shaft with Langets" tier="2" piece_type="Handle" mesh="french_voulge_shaft" length="130" weight="1.5" CraftingCost="120">
     <BuildData previous_piece_offset="0" next_piece_offset="0" piece_offset="30" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_handle_h3" name="Polearm Shaft with Langets" tier="2" piece_type="Handle" mesh="french_voulge_shaft" length="130" weight="3.1" CraftingCost="120">
+  <CraftingPiece id="crpg_french_voulge_handle_h3" name="Polearm Shaft with Langets" tier="2" piece_type="Handle" mesh="french_voulge_shaft" length="130" weight="1.5" CraftingCost="120">
     <BuildData previous_piece_offset="0" next_piece_offset="0" piece_offset="30" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -26671,7 +26667,7 @@
   <CraftingPiece id="crpg_burgundian_glaive_blade_h0" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.31">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26683,7 +26679,7 @@
   <CraftingPiece id="crpg_burgundian_glaive_blade_h1" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.28">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26695,7 +26691,7 @@
   <CraftingPiece id="crpg_burgundian_glaive_blade_h2" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.28">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26707,7 +26703,7 @@
   <CraftingPiece id="crpg_burgundian_glaive_blade_h3" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.28">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26743,7 +26739,7 @@
   <CraftingPiece id="crpg_burgundian_poleaxe_blade_h0" name="{=kaikaikai}Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.59">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26756,7 +26752,7 @@
   <CraftingPiece id="crpg_burgundian_poleaxe_blade_h1" name="{=kaikaikai}Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.59">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26769,7 +26765,7 @@
   <CraftingPiece id="crpg_burgundian_poleaxe_blade_h2" name="{=kaikaikai}Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.59">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26779,10 +26775,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_burgundian_poleaxe_blade_h3" name="{=kaikaikai}Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.59">
+  <CraftingPiece id="crpg_burgundian_poleaxe_blade_h3" name="{=kaikaikai}Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.53">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26895,7 +26891,7 @@
   <CraftingPiece id="crpg_bec_de_corbin_blade_h0" name="{=kaikaikai}Bec De Corbin Blade" tier="3" piece_type="Blade" mesh="bec_head" culture="Culture.vlandia" length="104" weight="0.4">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Pierce" damage_factor="3.0" />
+      <Swing damage_type="Pierce" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26907,7 +26903,7 @@
   <CraftingPiece id="crpg_bec_de_corbin_blade_h1" name="{=kaikaikai}Bec De Corbin Blade" tier="3" piece_type="Blade" mesh="bec_head" culture="Culture.vlandia" length="104" weight="0.35">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Pierce" damage_factor="3.0" />
+      <Swing damage_type="Pierce" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26919,7 +26915,7 @@
   <CraftingPiece id="crpg_bec_de_corbin_blade_h2" name="{=kaikaikai}Bec De Corbin Blade" tier="3" piece_type="Blade" mesh="bec_head" culture="Culture.vlandia" length="104" weight="0.35">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Pierce" damage_factor="3.1" />
+      <Swing damage_type="Pierce" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26931,7 +26927,7 @@
   <CraftingPiece id="crpg_bec_de_corbin_blade_h3" name="{=kaikaikai}Bec De Corbin Blade" tier="3" piece_type="Blade" mesh="bec_head" culture="Culture.vlandia" length="104" weight="0.35">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Pierce" damage_factor="3.2" />
+      <Swing damage_type="Pierce" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -31915,7 +31911,7 @@
   <CraftingPiece id="crpg_fangtian_ji_blade_h0" name="{=}Fangtian Ji Blade" tier="2" piece_type="Blade" mesh="qinglong_double_blade" length="45.8" weight="0.34" full_scale="true">
     <BladeData stack_amount="5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -31924,7 +31920,7 @@
   <CraftingPiece id="crpg_fangtian_ji_blade_h1" name="{=}Fangtian Ji Blade" tier="2" piece_type="Blade" mesh="qinglong_double_blade" length="45.8" weight="0.315" full_scale="true">
     <BladeData stack_amount="5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -31933,7 +31929,7 @@
   <CraftingPiece id="crpg_fangtian_ji_blade_h2" name="{=}Fangtian Ji Blade" tier="2" piece_type="Blade" mesh="qinglong_double_blade" length="45.8" weight="0.315" full_scale="true">
     <BladeData stack_amount="5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="5.0" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -31942,7 +31938,7 @@
   <CraftingPiece id="crpg_fangtian_ji_blade_h3" name="{=}Fangtian Ji Blade" tier="2" piece_type="Blade" mesh="qinglong_double_blade" length="45.8" weight="0.3" full_scale="true">
     <BladeData stack_amount="5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="5.0" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -32316,9 +32312,9 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_ironrod_pommel_h3" name="{=}None" tier="1" piece_type="Pommel" mesh="" culture="Culture.empire" length="0" weight="0" is_default="true">
   </CraftingPiece>
-  <CraftingPiece id="crpg_ironrod_blade_h0" name="{=}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.1">
+  <CraftingPiece id="crpg_ironrod_blade_h0" name="{=}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Blunt" damage_factor="2.4" />
+      <Thrust damage_type="Blunt" damage_factor="2.0" />
       <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
@@ -32328,9 +32324,9 @@
       <Flag name="NoBlood" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ironrod_blade_h1" name="{=}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.1">
+  <CraftingPiece id="crpg_ironrod_blade_h1" name="{=}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Blunt" damage_factor="2.5" />
+      <Thrust damage_type="Blunt" damage_factor="2.0" />
       <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
@@ -32340,10 +32336,10 @@
       <Flag name="NoBlood" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ironrod_blade_h2" name="{=}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.1">
+  <CraftingPiece id="crpg_ironrod_blade_h2" name="{=}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Blunt" damage_factor="2.5" />
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Thrust damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -32352,10 +32348,10 @@
       <Flag name="NoBlood" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ironrod_blade_h3" name="{=}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.1">
+  <CraftingPiece id="crpg_ironrod_blade_h3" name="{=}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Blunt" damage_factor="2.7" />
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Thrust damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -32364,25 +32360,25 @@
       <Flag name="NoBlood" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ironrod_handle_h0" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="ironrod_handle" length="204" weight="2.3" excluded_item_usage_features="long" is_default="true">
+  <CraftingPiece id="crpg_ironrod_handle_h0" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="ironrod_handle" length="204" weight="2.5" excluded_item_usage_features="long" is_default="true">
     <BuildData piece_offset="14.9" />
     <Materials>
       <Material id="Metal" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ironrod_handle_h1" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="ironrod_handle" length="204" weight="2.3" excluded_item_usage_features="long" is_default="true">
+  <CraftingPiece id="crpg_ironrod_handle_h1" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="ironrod_handle" length="204" weight="2.5" excluded_item_usage_features="long" is_default="true">
     <BuildData piece_offset="14.9" />
     <Materials>
       <Material id="Metal" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ironrod_handle_h2" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="ironrod_handle" length="204" weight="2.2" excluded_item_usage_features="long" is_default="true">
+  <CraftingPiece id="crpg_ironrod_handle_h2" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="ironrod_handle" length="204" weight="2.5" excluded_item_usage_features="long" is_default="true">
     <BuildData piece_offset="14.9" />
     <Materials>
       <Material id="Metal" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ironrod_handle_h3" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="ironrod_handle" length="204" weight="2.2" excluded_item_usage_features="long" is_default="true">
+  <CraftingPiece id="crpg_ironrod_handle_h3" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="ironrod_handle" length="204" weight="2.35" excluded_item_usage_features="long" is_default="true">
     <BuildData piece_offset="14.9" />
     <Materials>
       <Material id="Metal" count="1" />
@@ -32587,7 +32583,7 @@
   <CraftingPiece id="crpg_german_halberd_blade_h0" name="{=kaikaikai}German Halberd Blade" tier="3" piece_type="Blade" mesh="german_halberd_blade" culture="Culture.vlandia" length="68.8" weight="0.56">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.2" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="BonusAgainstShield" />
@@ -32600,7 +32596,7 @@
   <CraftingPiece id="crpg_german_halberd_blade_h1" name="{=kaikaikai}German Halberd Blade" tier="3" piece_type="Blade" mesh="german_halberd_blade" culture="Culture.vlandia" length="68.8" weight="0.56">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="BonusAgainstShield" />
@@ -32613,7 +32609,7 @@
   <CraftingPiece id="crpg_german_halberd_blade_h2" name="{=kaikaikai}German Halberd Blade" tier="3" piece_type="Blade" mesh="german_halberd_blade" culture="Culture.vlandia" length="68.8" weight="0.52">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="BonusAgainstShield" />
@@ -32626,7 +32622,7 @@
   <CraftingPiece id="crpg_german_halberd_blade_h3" name="{=kaikaikai}German Halberd Blade" tier="3" piece_type="Blade" mesh="german_halberd_blade" culture="Culture.vlandia" length="68.8" weight="0.52">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="BonusAgainstShield" />
@@ -33311,7 +33307,7 @@
   <CraftingPiece id="crpg_bill_blade_h0" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5" excluded_item_usage_features="shield:thrust">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33325,7 +33321,7 @@
   <CraftingPiece id="crpg_bill_blade_h1" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5" excluded_item_usage_features="shield:thrust">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33339,7 +33335,7 @@
   <CraftingPiece id="crpg_bill_blade_h2" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5" excluded_item_usage_features="shield:thrust">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33353,7 +33349,7 @@
   <CraftingPiece id="crpg_bill_blade_h3" name="{=}Cheap Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.5" excluded_item_usage_features="shield:thrust">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="4.2" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33470,7 +33466,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_english_bill_blade_h0" name="{=Salt}English Bill Blade" tier="3" piece_type="Blade" mesh="englishbill_blade" culture="Culture.vlandia" length="64.2" weight="0.53">
     <BladeData stack_amount="3" blade_length="64.2" blade_width="15.5" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
       <Swing damage_type="Pierce" damage_factor="3.1" />
     </BladeData>
     <Flags>
@@ -33484,8 +33480,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_english_bill_blade_h1" name="{=Salt}English Bill Blade" tier="3" piece_type="Blade" mesh="englishbill_blade" culture="Culture.vlandia" length="64.2" weight="0.53">
     <BladeData stack_amount="3" blade_length="64.2" blade_width="15.5" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Pierce" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Pierce" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33499,7 +33495,7 @@
   <CraftingPiece id="crpg_english_bill_blade_h2" name="{=Salt}English Bill Blade" tier="3" piece_type="Blade" mesh="englishbill_blade" culture="Culture.vlandia" length="64.2" weight="0.53">
     <BladeData stack_amount="3" blade_length="64.2" blade_width="15.5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Pierce" damage_factor="3.3" />
+      <Swing damage_type="Pierce" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33513,7 +33509,7 @@
   <CraftingPiece id="crpg_english_bill_blade_h3" name="{=Salt}English Bill Blade" tier="3" piece_type="Blade" mesh="englishbill_blade" culture="Culture.vlandia" length="64.2" weight="0.48">
     <BladeData stack_amount="3" blade_length="64.2" blade_width="15.5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Pierce" damage_factor="3.3" />
+      <Swing damage_type="Pierce" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -34571,8 +34567,8 @@
   <CraftingPiece id="crpg_greatlongaxe_blade_h0" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.40">
     <BuildData piece_offset="-14.0" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Blunt" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Thrust damage_type="Blunt" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -34586,8 +34582,8 @@
   <CraftingPiece id="crpg_greatlongaxe_blade_h1" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.40">
     <BuildData piece_offset="-14.0" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Blunt" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Thrust damage_type="Blunt" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -34601,8 +34597,8 @@
   <CraftingPiece id="crpg_greatlongaxe_blade_h2" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.40">
     <BuildData piece_offset="-14.0" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Blunt" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.9" />
+      <Thrust damage_type="Blunt" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -34616,8 +34612,8 @@
   <CraftingPiece id="crpg_greatlongaxe_blade_h3" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.40">
     <BuildData piece_offset="-14.0" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Blunt" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="5.0" />
+      <Thrust damage_type="Blunt" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35399,7 +35395,7 @@
   <CraftingPiece id="crpg_ancientvoulge_blade_h0" name="{=Yeldur}Ancient Voulge Blade" tier="3" piece_type="Blade" mesh="ancientvoulge_blade" culture="Culture.vlandia" length="49.7" weight="0.50">
     <BladeData stack_amount="3" blade_length="49.7" blade_width="15.0" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35409,7 +35405,7 @@
   <CraftingPiece id="crpg_ancientvoulge_blade_h1" name="{=Yeldur}Ancient Voulge Blade" tier="3" piece_type="Blade" mesh="ancientvoulge_blade" culture="Culture.vlandia" length="49.7" weight="0.50">
     <BladeData stack_amount="3" blade_length="49.7" blade_width="15.0" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="4.2" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35419,7 +35415,7 @@
   <CraftingPiece id="crpg_ancientvoulge_blade_h2" name="{=Yeldur}Ancient Voulge Blade" tier="3" piece_type="Blade" mesh="ancientvoulge_blade" culture="Culture.vlandia" length="49.7" weight="0.48">
     <BladeData stack_amount="3" blade_length="49.7" blade_width="15.0" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35429,7 +35425,7 @@
   <CraftingPiece id="crpg_ancientvoulge_blade_h3" name="{=Yeldur}Ancient Voulge Blade" tier="3" piece_type="Blade" mesh="ancientvoulge_blade" culture="Culture.vlandia" length="49.7" weight="0.44">
     <BladeData stack_amount="3" blade_length="49.7" blade_width="15.0" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35467,7 +35463,7 @@
   <CraftingPiece id="crpg_fabulousvoulge_blade_h0" name="{=Yeldur}Fabulous Voulge Blade" tier="3" piece_type="Blade" mesh="fabulous_voulge_head" culture="Culture.vlandia" length="65.5" weight="0.65">
     <BladeData stack_amount="3" blade_length="42.0" blade_width="14.5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35477,7 +35473,7 @@
   <CraftingPiece id="crpg_fabulousvoulge_blade_h1" name="{=Yeldur}Fabulous Voulge Blade" tier="3" piece_type="Blade" mesh="fabulous_voulge_head" culture="Culture.vlandia" length="65.5" weight="0.69">
     <BladeData stack_amount="3" blade_length="42.0" blade_width="14.5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35486,8 +35482,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fabulousvoulge_blade_h2" name="{=Yeldur}Fabulous Voulge Blade" tier="3" piece_type="Blade" mesh="fabulous_voulge_head" culture="Culture.vlandia" length="65.5" weight="0.69">
     <BladeData stack_amount="3" blade_length="42.0" blade_width="14.5" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.9" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35496,8 +35492,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fabulousvoulge_blade_h3" name="{=Yeldur}Fabulous Voulge Blade" tier="3" piece_type="Blade" mesh="fabulous_voulge_head" culture="Culture.vlandia" length="65.5" weight="0.69">
     <BladeData stack_amount="3" blade_length="42.0" blade_width="14.5" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.9" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -36531,7 +36527,7 @@
   <CraftingPiece id="crpg_at_partisan_blade_h0" name="Partisan Blade" tier="3" piece_type="Blade" mesh="partisan_blade" culture="Culture.vlandia" length="48" weight="0.21">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -36543,7 +36539,7 @@
   <CraftingPiece id="crpg_at_partisan_blade_h1" name="Partisan Blade" tier="3" piece_type="Blade" mesh="partisan_blade" culture="Culture.vlandia" length="48" weight="0.21">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -36555,7 +36551,7 @@
   <CraftingPiece id="crpg_at_partisan_blade_h2" name="Partisan Blade" tier="3" piece_type="Blade" mesh="partisan_blade" culture="Culture.vlandia" length="48" weight="0.21">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -36567,7 +36563,7 @@
   <CraftingPiece id="crpg_at_partisan_blade_h3" name="Partisan Blade" tier="3" piece_type="Blade" mesh="partisan_blade" culture="Culture.vlandia" length="48" weight="0.21">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -37155,7 +37151,7 @@
   <CraftingPiece id="crpg_celticspear_blade_h0" name="Celtic Spear Blade" tier="3" piece_type="Blade" mesh="celticspear_blade" culture="Culture.vlandia" length="46" weight="0.4">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -37167,7 +37163,7 @@
   <CraftingPiece id="crpg_celticspear_blade_h1" name="Celtic Spear Blade" tier="3" piece_type="Blade" mesh="celticspear_blade" culture="Culture.vlandia" length="46" weight="0.4">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.9" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -37179,7 +37175,7 @@
   <CraftingPiece id="crpg_celticspear_blade_h2" name="Celtic Spear Blade" tier="3" piece_type="Blade" mesh="celticspear_blade" culture="Culture.vlandia" length="46" weight="0.4">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -37188,10 +37184,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_celticspear_blade_h3" name="Celtic Spear Blade" tier="3" piece_type="Blade" mesh="celticspear_blade" culture="Culture.vlandia" length="46" weight="0.4">
+  <CraftingPiece id="crpg_celticspear_blade_h3" name="Celtic Spear Blade" tier="3" piece_type="Blade" mesh="celticspear_blade" culture="Culture.vlandia" length="46" weight="0.38">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -5538,7 +5538,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h0" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -5546,7 +5546,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h1" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -5554,7 +5554,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h2" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -5562,7 +5562,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h3" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.2" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -5879,7 +5879,7 @@
   <CraftingPiece id="crpg_menavlion_blade_h0" name="{=kaikaikai}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.56">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -5888,7 +5888,7 @@
   <CraftingPiece id="crpg_menavlion_blade_h1" name="{=kaikaikai}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.53">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -5897,7 +5897,7 @@
   <CraftingPiece id="crpg_menavlion_blade_h2" name="{=kaikaikai}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.53">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -5905,8 +5905,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_menavlion_blade_h3" name="{=kaikaikai}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.5">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -6010,7 +6010,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_rhomphaia_blade_h0" name="{=kaikaikai}Bent Razor Head" tier="4" piece_type="Blade" mesh="spear_blade_44" length="80" weight="0.7" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -6022,7 +6022,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_rhomphaia_blade_h1" name="{=kaikaikai}Bent Razor Head" tier="4" piece_type="Blade" mesh="spear_blade_44" length="80" weight="0.7" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.9" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -6034,7 +6034,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_rhomphaia_blade_h2" name="{=kaikaikai}Bent Razor Head" tier="4" piece_type="Blade" mesh="spear_blade_44" length="80" weight="0.7" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="5.1" />
+      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -6046,7 +6046,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_rhomphaia_blade_h3" name="{=kaikaikai}Bent Razor Head" tier="4" piece_type="Blade" mesh="spear_blade_44" length="80" weight="0.67" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="5.1" />
+      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -6059,7 +6059,7 @@
   <CraftingPiece id="crpg_warrazor_blade_h0" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.56" excluded_item_usage_features="">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -6068,7 +6068,7 @@
   <CraftingPiece id="crpg_warrazor_blade_h1" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.53" excluded_item_usage_features="">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -6077,7 +6077,7 @@
   <CraftingPiece id="crpg_warrazor_blade_h2" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.5" excluded_item_usage_features="">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -6086,7 +6086,7 @@
   <CraftingPiece id="crpg_warrazor_blade_h3" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.46" excluded_item_usage_features="">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -6095,7 +6095,7 @@
   <CraftingPiece id="crpg_long_glaive_blade_h0" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.4">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
@@ -6104,7 +6104,7 @@
   <CraftingPiece id="crpg_long_glaive_blade_h1" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.37">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
@@ -6113,7 +6113,7 @@
   <CraftingPiece id="crpg_long_glaive_blade_h2" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.37">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
@@ -6122,7 +6122,7 @@
   <CraftingPiece id="crpg_long_glaive_blade_h3" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.34">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.8" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
@@ -26827,7 +26827,7 @@
   <CraftingPiece id="crpg_simple_poleaxe_blade_h0" name="{=kaikaikai}Simple Poleaxe Blade" tier="3" piece_type="Blade" mesh="simple_poleaxe_head" culture="Culture.vlandia" length="46.6" weight="0.4">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.9" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26840,7 +26840,7 @@
   <CraftingPiece id="crpg_simple_poleaxe_blade_h1" name="{=kaikaikai}Simple Poleaxe Blade" tier="3" piece_type="Blade" mesh="simple_poleaxe_head" culture="Culture.vlandia" length="46.6" weight="0.37">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26853,7 +26853,7 @@
   <CraftingPiece id="crpg_simple_poleaxe_blade_h2" name="{=kaikaikai}Simple Poleaxe Blade" tier="3" piece_type="Blade" mesh="simple_poleaxe_head" culture="Culture.vlandia" length="46.6" weight="0.37">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26866,7 +26866,7 @@
   <CraftingPiece id="crpg_simple_poleaxe_blade_h3" name="{=kaikaikai}Simple Poleaxe Blade" tier="3" piece_type="Blade" mesh="simple_poleaxe_head" culture="Culture.vlandia" length="46.6" weight="0.37">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26974,8 +26974,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spiked_polehammer_blade_h0" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.42">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Blunt" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26986,8 +26986,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spiked_polehammer_blade_h1" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.42">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26998,8 +26998,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spiked_polehammer_blade_h2" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.42">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -27008,10 +27008,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_blade_h3" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.42">
+  <CraftingPiece id="crpg_spiked_polehammer_blade_h3" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.38">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -27039,82 +27039,6 @@
     </Materials>
   </CraftingPiece>
   <CraftingPiece id="crpg_spiked_polehammer_handle_h3" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="2.0" CraftingCost="120">
-    <BuildData previous_piece_offset="0" next_piece_offset="72" piece_offset="44" />
-    <Materials>
-      <Material id="Wood" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_knockdown_blade_h0" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.42">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Blunt" damage_factor="2.6" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_knockdown_blade_h1" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.42">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="2.7" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_knockdown_blade_h2" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.42">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="2.8" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_knockdown_blade_h3" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.42">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="2.9" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_knockdown_handle_h0" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="2.0" CraftingCost="120">
-    <BuildData previous_piece_offset="0" next_piece_offset="72" piece_offset="44" />
-    <Materials>
-      <Material id="Wood" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_knockdown_handle_h1" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="2.0" CraftingCost="120">
-    <BuildData previous_piece_offset="0" next_piece_offset="72" piece_offset="44" />
-    <Materials>
-      <Material id="Wood" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_knockdown_handle_h2" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="2.0" CraftingCost="120">
-    <BuildData previous_piece_offset="0" next_piece_offset="72" piece_offset="44" />
-    <Materials>
-      <Material id="Wood" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_knockdown_handle_h3" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="2.0" CraftingCost="120">
     <BuildData previous_piece_offset="0" next_piece_offset="72" piece_offset="44" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -31463,7 +31387,7 @@
   <CraftingPiece id="crpg_pudao_blade_h0" name="{=}Pudao Blade" tier="2" piece_type="Blade" mesh="pudao_blade" length="71.1" weight="0.95">
     <BladeData stack_amount="5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -31472,7 +31396,7 @@
   <CraftingPiece id="crpg_pudao_blade_h1" name="{=}Pudao Blade" tier="2" piece_type="Blade" mesh="pudao_blade" length="71.1" weight="0.9">
     <BladeData stack_amount="5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -31481,7 +31405,7 @@
   <CraftingPiece id="crpg_pudao_blade_h2" name="{=}Pudao Blade" tier="2" piece_type="Blade" mesh="pudao_blade" length="71.1" weight="0.9">
     <BladeData stack_amount="5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="5.0" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -31490,7 +31414,7 @@
   <CraftingPiece id="crpg_pudao_blade_h3" name="{=}Pudao Blade" tier="2" piece_type="Blade" mesh="pudao_blade" length="71.1" weight="0.85">
     <BladeData stack_amount="5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="5.0" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -31767,8 +31691,8 @@
   <CraftingPiece id="crpg_meowaxe_blade_h0" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.82">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Blunt" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Thrust damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -31782,8 +31706,8 @@
   <CraftingPiece id="crpg_meowaxe_blade_h1" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.78">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Blunt" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Thrust damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -31797,8 +31721,8 @@
   <CraftingPiece id="crpg_meowaxe_blade_h2" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.75">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Blunt" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Thrust damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -31812,8 +31736,8 @@
   <CraftingPiece id="crpg_meowaxe_blade_h3" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.75">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Blunt" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="5.0" />
+      <Thrust damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33236,7 +33160,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33250,7 +33174,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33264,7 +33188,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33278,7 +33202,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33424,7 +33348,7 @@
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.2" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33438,7 +33362,7 @@
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33452,7 +33376,7 @@
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33466,7 +33390,7 @@
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33815,7 +33739,7 @@
   <CraftingPiece id="crpg_swiss_halberd_blade_h0" name="Swiss Halberd Blade" tier="3" piece_type="Blade" mesh="swiss_halberd_blade" culture="Culture.vlandia" length="109" weight="0.05">
     <BladeData stack_amount="3" blade_length="109.0" blade_width="13.5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33828,7 +33752,7 @@
   <CraftingPiece id="crpg_swiss_halberd_blade_h1" name="{=Salt}Swiss Halberd Blade" tier="3" piece_type="Blade" mesh="swiss_halberd_blade" culture="Culture.vlandia" length="109" weight="0.05">
     <BladeData stack_amount="3" blade_length="109.0" blade_width="13.5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33841,7 +33765,7 @@
   <CraftingPiece id="crpg_swiss_halberd_blade_h2" name="{=Salt}Swiss Halberd Blade" tier="3" piece_type="Blade" mesh="swiss_halberd_blade" culture="Culture.vlandia" length="109" weight="0.02">
     <BladeData stack_amount="3" blade_length="109.0" blade_width="13.5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -33854,7 +33778,7 @@
   <CraftingPiece id="crpg_swiss_halberd_blade_h3" name="{=Salt}Swiss Halberd Blade" tier="3" piece_type="Blade" mesh="swiss_halberd_blade" culture="Culture.vlandia" length="109" weight="0.02">
     <BladeData stack_amount="3" blade_length="109.0" blade_width="13.5" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35912,7 +35836,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35926,7 +35850,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35939,8 +35863,8 @@
   <CraftingPiece id="crpg_long_bardiche_blade_h2" name="{=}Long Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.75">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Cut" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Thrust damage_type="Cut" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -35954,7 +35878,7 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Cut" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -882,7 +882,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_bone_crusher_blade_h0" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.55" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -890,7 +890,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_bone_crusher_blade_h1" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.5" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -898,7 +898,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_bone_crusher_blade_h2" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.5" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -906,7 +906,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_bone_crusher_blade_h3" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.44" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -946,7 +946,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_heavy_flanged_mace_blade_h0" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="1.5" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -954,7 +954,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_heavy_flanged_mace_blade_h1" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="1.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -962,7 +962,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_heavy_flanged_mace_blade_h2" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="1.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -970,7 +970,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_heavy_flanged_mace_blade_h3" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="1.35" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -978,7 +978,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_decorated_round_mace_blade_h0" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.85" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.8" />
+      <Swing damage_type="Blunt" damage_factor="2.0" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -986,7 +986,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_decorated_round_mace_blade_h1" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.85" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.9" />
+      <Swing damage_type="Blunt" damage_factor="2.1" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -994,15 +994,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_decorated_round_mace_blade_h2" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.85" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_round_mace_blade_h3" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.85" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_decorated_round_mace_blade_h3" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.82" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1013,6 +1013,7 @@
       <Swing damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Flags>
+      <Flag name="BonusAgainstShield" />
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
     </Flags>
     <Materials>
@@ -1024,6 +1025,7 @@
       <Swing damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Flags>
+      <Flag name="BonusAgainstShield" />
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
     </Flags>
     <Materials>
@@ -1035,6 +1037,7 @@
       <Swing damage_type="Pierce" damage_factor="2.9" />
     </BladeData>
     <Flags>
+      <Flag name="BonusAgainstShield" />
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
     </Flags>
     <Materials>
@@ -1046,6 +1049,7 @@
       <Swing damage_type="Pierce" damage_factor="3.0" />
     </BladeData>
     <Flags>
+      <Flag name="BonusAgainstShield" />
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
     </Flags>
     <Materials>
@@ -1057,6 +1061,7 @@
       <Swing damage_type="Pierce" damage_factor="2.4" />
     </BladeData>
     <Flags>
+      <Flag name="BonusAgainstShield" />
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
     </Flags>
     <Materials>
@@ -1069,6 +1074,7 @@
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1080,6 +1086,7 @@
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1091,6 +1098,7 @@
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1146,7 +1154,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_steel_flanged_mace_blade_h0" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1154,7 +1162,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_steel_flanged_mace_blade_h1" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1162,15 +1170,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_steel_flanged_mace_blade_h2" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_flanged_mace_blade_h3" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_steel_flanged_mace_blade_h3" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.85" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1178,7 +1186,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_steel_winged_shestopyor_blade_h0" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.47" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1186,7 +1194,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_steel_winged_shestopyor_blade_h1" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.47" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1194,15 +1202,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_steel_winged_shestopyor_blade_h2" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.47" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_winged_shestopyor_blade_h3" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.47" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_steel_winged_shestopyor_blade_h3" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.46" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1210,7 +1218,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_shishpar_mace_blade_h0" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="1.05" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -1218,7 +1226,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_shishpar_mace_blade_h1" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="1.05" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -1226,15 +1234,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_shishpar_mace_blade_h2" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="1.05" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_shishpar_mace_blade_h3" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="1.05" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_shishpar_mace_blade_h3" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="1.0" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -1335,7 +1343,7 @@
   <CraftingPiece id="crpg_blacksmith_hammer_blade_h0" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-10" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.9" />
+      <Swing damage_type="Blunt" damage_factor="2.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1347,7 +1355,7 @@
   <CraftingPiece id="crpg_blacksmith_hammer_blade_h1" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-10" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1359,7 +1367,7 @@
   <CraftingPiece id="crpg_blacksmith_hammer_blade_h2" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-10" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1368,7 +1376,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_blade_h3" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_hammer_blade_h3" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.85" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-10" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.2" />
@@ -1383,7 +1391,7 @@
   <CraftingPiece id="crpg_blacksmith_warhammer_blade_h0" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1396,7 +1404,7 @@
   <CraftingPiece id="crpg_blacksmith_warhammer_blade_h1" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1409,7 +1417,7 @@
   <CraftingPiece id="crpg_blacksmith_warhammer_blade_h2" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1419,10 +1427,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_warhammer_blade_h3" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_warhammer_blade_h3" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.3" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1435,7 +1443,7 @@
   <CraftingPiece id="crpg_highland_spiked_club_blade_h0" name="{=0SpLcthg}Highland Spiked Club" tier="2" piece_type="Blade" mesh="mace_head_5" length="25.5" weight="0.52" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1445,7 +1453,7 @@
   <CraftingPiece id="crpg_highland_spiked_club_blade_h1" name="{=0SpLcthg}Highland Spiked Club" tier="2" piece_type="Blade" mesh="mace_head_5" length="25.5" weight="0.48" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1455,7 +1463,7 @@
   <CraftingPiece id="crpg_highland_spiked_club_blade_h2" name="{=0SpLcthg}Highland Spiked Club" tier="2" piece_type="Blade" mesh="mace_head_5" length="25.5" weight="0.48" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1465,7 +1473,7 @@
   <CraftingPiece id="crpg_highland_spiked_club_blade_h3" name="{=0SpLcthg}Highland Spiked Club" tier="2" piece_type="Blade" mesh="mace_head_5" length="25.5" weight="0.48" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.7" />
+      <Swing damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1474,7 +1482,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knobbed_ball_club_blade_h0" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="1.25" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1482,7 +1490,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knobbed_ball_club_blade_h1" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="1.15" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1490,15 +1498,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knobbed_ball_club_blade_h2" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="1.15" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knobbed_ball_club_blade_h3" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="1.15" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_knobbed_ball_club_blade_h3" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="1.1" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1506,7 +1514,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fine_steel_mace_blade_h0" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.31" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -1514,7 +1522,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fine_steel_mace_blade_h1" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.31" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -1522,15 +1530,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fine_steel_mace_blade_h2" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.30" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_mace_blade_h3" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.30" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fine_steel_mace_blade_h3" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.29" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.9" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -1538,7 +1546,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_eastern_heavy_mace_blade_h0" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.43" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="5" />
@@ -1546,7 +1554,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_eastern_heavy_mace_blade_h1" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.43" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="5" />
@@ -1554,7 +1562,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_eastern_heavy_mace_blade_h2" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.43" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="5" />
@@ -1562,7 +1570,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_eastern_heavy_mace_blade_h3" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.42" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="5" />
@@ -1571,7 +1579,7 @@
   <CraftingPiece id="crpg_steppe_spiked_mace_blade_h0" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="0.88" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="0.8" />
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1580,7 +1588,7 @@
   <CraftingPiece id="crpg_steppe_spiked_mace_blade_h1" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="0.84" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="0.9" />
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1589,16 +1597,16 @@
   <CraftingPiece id="crpg_steppe_spiked_mace_blade_h2" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="0.84" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.0" />
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steppe_spiked_mace_blade_h3" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="0.84" full_scale="true">
+  <CraftingPiece id="crpg_steppe_spiked_mace_blade_h3" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="0.8" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.1" />
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1606,7 +1614,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spiralled_mace_blade_h0" name="{=rSs1M2EJ}Spiralled Mace Head" tier="4" piece_type="Blade" mesh="mace_head_15" length="13.5" weight="0.48" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1614,7 +1622,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spiralled_mace_blade_h1" name="{=rSs1M2EJ}Spiralled Mace Head" tier="4" piece_type="Blade" mesh="mace_head_15" length="13.5" weight="0.48" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1622,7 +1630,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spiralled_mace_blade_h2" name="{=rSs1M2EJ}Spiralled Mace Head" tier="4" piece_type="Blade" mesh="mace_head_15" length="13.5" weight="0.48" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1630,7 +1638,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spiralled_mace_blade_h3" name="{=rSs1M2EJ}Spiralled Mace Head" tier="4" piece_type="Blade" mesh="mace_head_15" length="13.5" weight="0.48" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1638,7 +1646,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_heavy_horsemans_mace_blade_h0" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1646,7 +1654,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_heavy_horsemans_mace_blade_h1" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1654,15 +1662,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_heavy_horsemans_mace_blade_h2" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_horsemans_mace_blade_h3" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_heavy_horsemans_mace_blade_h3" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.3" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1670,7 +1678,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knights_fall_blade_h0" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.53" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1678,7 +1686,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knights_fall_blade_h1" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.53" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1686,15 +1694,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knights_fall_blade_h2" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.53" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knights_fall_blade_h3" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.53" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_knights_fall_blade_h3" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.5" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1702,7 +1710,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_rus_mace_blade_h0" name="{=b9bboB3v}Southern Infantry Mace Head" tier="2" piece_type="Blade" mesh="mace_head_17" length="8.1" weight="1.15" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1710,7 +1718,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_rus_mace_blade_h1" name="{=b9bboB3v}Southern Infantry Mace Head" tier="2" piece_type="Blade" mesh="mace_head_17" length="8.1" weight="1.15" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1718,7 +1726,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_rus_mace_blade_h2" name="{=b9bboB3v}Southern Infantry Mace Head" tier="2" piece_type="Blade" mesh="mace_head_17" length="8.1" weight="1.15" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1726,7 +1734,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_rus_mace_blade_h3" name="{=b9bboB3v}Southern Infantry Mace Head" tier="2" piece_type="Blade" mesh="mace_head_17" length="8.1" weight="1.1" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1734,7 +1742,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_winged_mace_blade_h0" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.682" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1742,7 +1750,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_winged_mace_blade_h1" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.682" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1750,15 +1758,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_winged_mace_blade_h2" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.682" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_winged_mace_blade_h3" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.682" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
+  <CraftingPiece id="crpg_light_winged_mace_blade_h3" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.64" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1766,7 +1774,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_cataphract_mace_blade_h0" name="{=IR8UeIRp}Cataphracts Mace Head" tier="5" piece_type="Blade" mesh="mace_head_7" length="22" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1774,7 +1782,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_cataphract_mace_blade_h1" name="{=IR8UeIRp}Cataphracts Mace Head" tier="5" piece_type="Blade" mesh="mace_head_7" length="22" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1782,7 +1790,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_cataphract_mace_blade_h2" name="{=IR8UeIRp}Cataphracts Mace Head" tier="5" piece_type="Blade" mesh="mace_head_7" length="22" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.9" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1798,7 +1806,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_royal_mace_blade_h0" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.8" />
+      <Swing damage_type="Blunt" damage_factor="2.0" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1806,7 +1814,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_royal_mace_blade_h1" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.9" />
+      <Swing damage_type="Blunt" damage_factor="2.1" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1814,15 +1822,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_royal_mace_blade_h2" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_royal_mace_blade_h3" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_royal_mace_blade_h3" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.34" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1830,7 +1838,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_calradic_mace_blade_h0" name="{=trGnmFsh}Calradic Mace Head" tier="4" piece_type="Blade" mesh="mace_head_8" length="7" weight="0.3" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1838,7 +1846,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_calradic_mace_blade_h1" name="{=trGnmFsh}Calradic Mace Head" tier="4" piece_type="Blade" mesh="mace_head_8" length="7" weight="0.3" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1846,15 +1854,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_calradic_mace_blade_h2" name="{=trGnmFsh}Calradic Mace Head" tier="4" piece_type="Blade" mesh="mace_head_8" length="7" weight="0.3" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_calradic_mace_blade_h3" name="{=trGnmFsh}Calradic Mace Head" tier="4" piece_type="Blade" mesh="mace_head_8" length="7" weight="0.29" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_calradic_mace_blade_h3" name="{=trGnmFsh}Calradic Mace Head" tier="4" piece_type="Blade" mesh="mace_head_8" length="7" weight="0.27" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1862,7 +1870,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_star_pointed_mace_blade_h0" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1870,7 +1878,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_star_pointed_mace_blade_h1" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.81" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1878,15 +1886,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_star_pointed_mace_blade_h2" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.81" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_pointed_mace_blade_h3" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.81" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_star_pointed_mace_blade_h3" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.76" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1894,7 +1902,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_judgement_blade_h0" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.255" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1902,7 +1910,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_judgement_blade_h1" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.255" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1910,15 +1918,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_judgement_blade_h2" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.255" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.9" />
+      <Swing damage_type="Blunt" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_judgement_blade_h3" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.245" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_judgement_blade_h3" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.24" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="3.0" />
+      <Swing damage_type="Blunt" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1927,7 +1935,7 @@
   <CraftingPiece id="crpg_spiked_club_blade_h0" name="{=L3vLdPJT}Improved Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_23" distance_to_next_piece="15.4" distance_to_previous_piece="8.2" weight="0.8" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Pierce" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1936,7 +1944,7 @@
   <CraftingPiece id="crpg_spiked_club_blade_h1" name="{=L3vLdPJT}Improved Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_23" distance_to_next_piece="15.4" distance_to_previous_piece="8.2" weight="0.76" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Pierce" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1945,7 +1953,7 @@
   <CraftingPiece id="crpg_spiked_club_blade_h2" name="{=L3vLdPJT}Improved Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_23" distance_to_next_piece="15.4" distance_to_previous_piece="8.2" weight="0.76" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Pierce" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1954,7 +1962,7 @@
   <CraftingPiece id="crpg_spiked_club_blade_h3" name="{=L3vLdPJT}Improved Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_23" distance_to_next_piece="15.4" distance_to_previous_piece="8.2" weight="0.76" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1962,7 +1970,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_steel_pernach_blade_h0" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.28" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1970,7 +1978,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_steel_pernach_blade_h1" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.28" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1978,7 +1986,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_steel_pernach_blade_h2" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.27" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1986,7 +1994,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_steel_pernach_blade_h3" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.26" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1994,7 +2002,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_militia_pernach_blade_h0" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.35" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -2002,7 +2010,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_militia_pernach_blade_h1" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.35" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -2010,15 +2018,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_militia_pernach_blade_h2" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.35" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_militia_pernach_blade_h3" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.35" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_militia_pernach_blade_h3" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -2026,7 +2034,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fullered_western_mace_blade_h0" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -2034,7 +2042,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fullered_western_mace_blade_h1" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -2042,15 +2050,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fullered_western_mace_blade_h2" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fullered_western_mace_blade_h3" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fullered_western_mace_blade_h3" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="0.38" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -2059,7 +2067,7 @@
   <CraftingPiece id="crpg_spiked_mace_blade_h0" name="{=lZoqaYmx}Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_22" distance_to_next_piece="7.6" distance_to_previous_piece="4.1" weight="0.5" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="0.9" />
-      <Swing damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -2068,7 +2076,7 @@
   <CraftingPiece id="crpg_spiked_mace_blade_h1" name="{=lZoqaYmx}Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_22" distance_to_next_piece="7.6" distance_to_previous_piece="4.1" weight="0.5" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.0" />
-      <Swing damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -2077,7 +2085,7 @@
   <CraftingPiece id="crpg_spiked_mace_blade_h2" name="{=lZoqaYmx}Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_22" distance_to_next_piece="7.6" distance_to_previous_piece="4.1" weight="0.5" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.0" />
-      <Swing damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -2085,8 +2093,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spiked_mace_blade_h3" name="{=lZoqaYmx}Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_22" distance_to_next_piece="7.6" distance_to_previous_piece="4.1" weight="0.5" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="1.0" />
-      <Swing damage_type="Pierce" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.2" />
+      <Swing damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -26038,6 +26046,7 @@
       <Swing damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Flags>
+      <Flag name="BonusAgainstShield" />
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
     </Flags>
     <Materials>
@@ -26051,6 +26060,7 @@
       <Swing damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
     <Flags>
+      <Flag name="BonusAgainstShield" />
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
     </Flags>
     <Materials>
@@ -26064,6 +26074,7 @@
       <Swing damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Flags>
+      <Flag name="BonusAgainstShield" />
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
     </Flags>
     <Materials>
@@ -26077,6 +26088,7 @@
       <Swing damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Flags>
+      <Flag name="BonusAgainstShield" />
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
     </Flags>
     <Materials>
@@ -26388,7 +26400,7 @@
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -26398,7 +26410,7 @@
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -26408,7 +26420,7 @@
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -26418,7 +26430,7 @@
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -26452,7 +26464,7 @@
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -26462,7 +26474,7 @@
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -26472,17 +26484,17 @@
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_medium_goedendag_blade_h3" name="{=}Medium Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_short_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.9" weight="0.95" full_scale="true">
+  <CraftingPiece id="crpg_medium_goedendag_blade_h3" name="{=}Medium Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_short_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.9" weight="0.9" full_scale="true">
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -27111,7 +27123,7 @@
   <CraftingPiece id="crpg_military_hammer_blade_h0" name="{=}Military Hammer Head" tier="4" piece_type="Blade" mesh="military_hammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.4" weight="0.52" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -27123,7 +27135,7 @@
   <CraftingPiece id="crpg_military_hammer_blade_h1" name="{=}Military Hammer Head" tier="4" piece_type="Blade" mesh="military_hammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.4" weight="0.52" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -27135,7 +27147,7 @@
   <CraftingPiece id="crpg_military_hammer_blade_h2" name="{=}Military Hammer Head" tier="4" piece_type="Blade" mesh="military_hammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.4" weight="0.52" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -27144,10 +27156,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_military_hammer_blade_h3" name="{=}Military Hammer Head" tier="4" piece_type="Blade" mesh="military_hammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.4" weight="0.52" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_military_hammer_blade_h3" name="{=}Military Hammer Head" tier="4" piece_type="Blade" mesh="military_hammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.4" weight="0.48" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -27184,7 +27196,7 @@
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -27194,7 +27206,7 @@
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -27204,17 +27216,17 @@
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_warhammer_blade_h3" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.57" full_scale="true">
+  <CraftingPiece id="crpg_warhammer_blade_h3" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.55" full_scale="true">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -28918,7 +28930,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_cavalry_mace_blade_h0" name="{=}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.38" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -28926,7 +28938,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_cavalry_mace_blade_h1" name="{=}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.38" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -28934,15 +28946,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_cavalry_mace_blade_h2" name="{=}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.38" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_cavalry_mace_blade_h3" name="{=}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.38" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_long_cavalry_mace_blade_h3" name="{=}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -28974,7 +28986,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_pernach_blade_h0" name="{=Telford}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.43" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -28982,7 +28994,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_pernach_blade_h1" name="{=Telford}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -28990,7 +29002,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_pernach_blade_h2" name="{=Telford}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -28998,7 +29010,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_long_pernach_blade_h3" name="{=Telford}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -29034,7 +29046,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_persian_steel_mace_blade_h0" name="{=CeeJmlSq}Heavy Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_38" length="15.2" weight="1.2" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -29042,7 +29054,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_persian_steel_mace_blade_h1" name="{=CeeJmlSq}Heavy Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_38" length="15.2" weight="1.2" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -29050,15 +29062,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_persian_steel_mace_blade_h2" name="{=CeeJmlSq}Heavy Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_38" length="15.2" weight="1.2" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_persian_steel_mace_blade_h3" name="{=CeeJmlSq}Heavy Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_38" length="15.2" weight="1.2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_persian_steel_mace_blade_h3" name="{=CeeJmlSq}Heavy Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_38" length="15.2" weight="1.15" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -29114,7 +29126,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_flanged_mace_blade_h0" name="{=WrvDoYKa}Heavy Long Flanged Mace Head" tier="4" piece_type="Blade" mesh="mace_head_32" length="28" weight="1.3" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -29122,7 +29134,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_flanged_mace_blade_h1" name="{=WrvDoYKa}Heavy Long Flanged Mace Head" tier="4" piece_type="Blade" mesh="mace_head_32" length="28" weight="1.3" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -29130,7 +29142,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_flanged_mace_blade_h2" name="{=WrvDoYKa}Heavy Long Flanged Mace Head" tier="4" piece_type="Blade" mesh="mace_head_32" length="28" weight="1.3" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -29138,7 +29150,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_flanged_mace_blade_h3" name="{=WrvDoYKa}Heavy Long Flanged Mace Head" tier="4" piece_type="Blade" mesh="mace_head_32" length="28" weight="1.2" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -29194,7 +29206,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_arabian_mace_blade_h0" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.74" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -29202,7 +29214,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_arabian_mace_blade_h1" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.74" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -29210,7 +29222,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_arabian_mace_blade_h2" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.74" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.9" />
+      <Swing damage_type="Blunt" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -29218,7 +29230,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_arabian_mace_blade_h3" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.71" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="3.0" />
+      <Swing damage_type="Blunt" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -29334,7 +29346,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_byzantine_mace_blade_h0" name="{=6xkt7bxz}Heavy Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_18" length="8.4" weight="0.87" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -29342,7 +29354,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_byzantine_mace_blade_h1" name="{=6xkt7bxz}Heavy Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_18" length="8.4" weight="0.87" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -29350,15 +29362,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_byzantine_mace_blade_h2" name="{=6xkt7bxz}Heavy Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_18" length="8.4" weight="0.87" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_byzantine_mace_blade_h3" name="{=6xkt7bxz}Heavy Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_18" length="8.4" weight="0.85" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_byzantine_mace_blade_h3" name="{=6xkt7bxz}Heavy Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_18" length="8.4" weight="0.83" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -29394,7 +29406,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_shestopyor_blade_h0" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="0.7" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -29402,7 +29414,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_shestopyor_blade_h1" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="0.64" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -29410,7 +29422,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_shestopyor_blade_h2" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="0.64" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -29418,7 +29430,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_shestopyor_blade_h3" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="0.62" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -29474,7 +29486,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knobbed_mace_blade_h0" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="5" />
@@ -29482,7 +29494,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knobbed_mace_blade_h1" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="5" />
@@ -29490,15 +29502,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knobbed_mace_blade_h2" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="5" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knobbed_mace_blade_h3" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.9" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_knobbed_mace_blade_h3" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.85" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="5" />
@@ -31332,65 +31344,65 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_horsemanspick_head_h0" name="{=}Horseman's Pick Head" tier="4" piece_type="Blade" mesh="horsemanspick_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="46.2" weight="0.9" full_scale="true">
+  <CraftingPiece id="crpg_horsemanspick_head_h0" name="{=}Horseman's Pick Head" tier="4" piece_type="Blade" mesh="horsemanspick_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="46.2" weight="0.5" full_scale="true">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Pierce" damage_factor="2.5" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_horsemanspick_head_h1" name="{=}Horseman's Pick Head" tier="4" piece_type="Blade" mesh="horsemanspick_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="46.2" weight="0.9" full_scale="true">
-    <BuildData piece_offset="0.0" />
-    <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Pierce" damage_factor="2.6" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_horsemanspick_head_h2" name="{=}Horseman's Pick Head" tier="4" piece_type="Blade" mesh="horsemanspick_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="46.2" weight="0.9" full_scale="true">
-    <BuildData piece_offset="0.0" />
-    <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Pierce" damage_factor="2.7" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_horsemanspick_head_h3" name="{=}Horseman's Pick Head" tier="4" piece_type="Blade" mesh="horsemanspick_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="46.2" weight="0.9" full_scale="true">
-    <BuildData piece_offset="0.0" />
-    <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_horsemanspick_handle_h0" name="{=}Horseman's Pick Handle" tier="4" piece_type="Handle" mesh="horsemanspick_handle" length="77.2" weight="0.323" item_holster_pos_shift="0,0,-0.1" CraftingCost="90">
+  <CraftingPiece id="crpg_horsemanspick_head_h1" name="{=}Horseman's Pick Head" tier="4" piece_type="Blade" mesh="horsemanspick_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="46.2" weight="0.5" full_scale="true">
+    <BuildData piece_offset="0.0" />
+    <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Pierce" damage_factor="2.9" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_horsemanspick_head_h2" name="{=}Horseman's Pick Head" tier="4" piece_type="Blade" mesh="horsemanspick_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="46.2" weight="0.5" full_scale="true">
+    <BuildData piece_offset="0.0" />
+    <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Pierce" damage_factor="3.0" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_horsemanspick_head_h3" name="{=}Horseman's Pick Head" tier="4" piece_type="Blade" mesh="horsemanspick_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="46.2" weight="0.45" full_scale="true">
+    <BuildData piece_offset="0.0" />
+    <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Pierce" damage_factor="3.0" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_horsemanspick_handle_h0" name="{=}Horseman's Pick Handle" tier="4" piece_type="Handle" mesh="horsemanspick_handle" length="77.2" weight="0.75" item_holster_pos_shift="0,0,-0.1" CraftingCost="90">
     <BuildData piece_offset="20.0" next_piece_offset="21.0" />
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_horsemanspick_handle_h1" name="{=}Horseman's Pick Handle" tier="4" piece_type="Handle" mesh="horsemanspick_handle" length="77.2" weight="0.323" item_holster_pos_shift="0,0,-0.1" CraftingCost="90">
+  <CraftingPiece id="crpg_horsemanspick_handle_h1" name="{=}Horseman's Pick Handle" tier="4" piece_type="Handle" mesh="horsemanspick_handle" length="77.2" weight="0.75" item_holster_pos_shift="0,0,-0.1" CraftingCost="90">
     <BuildData piece_offset="20.0" next_piece_offset="21.0" />
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_horsemanspick_handle_h2" name="{=}Horseman's Pick Handle" tier="4" piece_type="Handle" mesh="horsemanspick_handle" length="77.2" weight="0.323" item_holster_pos_shift="0,0,-0.1" CraftingCost="90">
+  <CraftingPiece id="crpg_horsemanspick_handle_h2" name="{=}Horseman's Pick Handle" tier="4" piece_type="Handle" mesh="horsemanspick_handle" length="77.2" weight="0.75" item_holster_pos_shift="0,0,-0.1" CraftingCost="90">
     <BuildData piece_offset="20.0" next_piece_offset="21.0" />
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_horsemanspick_handle_h3" name="{=}Horseman's Pick Handle" tier="4" piece_type="Handle" mesh="horsemanspick_handle" length="77.2" weight="0.323" item_holster_pos_shift="0,0,-0.1" CraftingCost="90">
+  <CraftingPiece id="crpg_horsemanspick_handle_h3" name="{=}Horseman's Pick Handle" tier="4" piece_type="Handle" mesh="horsemanspick_handle" length="77.2" weight="0.75" item_holster_pos_shift="0,0,-0.1" CraftingCost="90">
     <BuildData piece_offset="20.0" next_piece_offset="21.0" />
     <Materials>
       <Material id="Iron4" count="3" />
@@ -32210,7 +32222,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_onehanded_gada_blade_h0" name="{=}Steel Ball Mace Head" tier="2" piece_type="Blade" mesh="gada_blade" length="27.9" weight="3.5" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -32218,7 +32230,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_onehanded_gada_blade_h1" name="{=}Steel Ball Mace Head" tier="2" piece_type="Blade" mesh="gada_blade" length="27.9" weight="3.2" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -32226,15 +32238,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_onehanded_gada_blade_h2" name="{=}Steel Ball Mace Head" tier="2" piece_type="Blade" mesh="gada_blade" length="27.9" weight="3.2" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_onehanded_gada_blade_h3" name="{=}Steel Ball Mace Head" tier="2" piece_type="Blade" mesh="gada_blade" length="27.9" weight="3.2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_onehanded_gada_blade_h3" name="{=}Steel Ball Mace Head" tier="2" piece_type="Blade" mesh="gada_blade" length="27.9" weight="3.0" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -32242,7 +32254,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_onehanded_barmace_blade_h0" name="{=}Onehanded Barmace Blade" tier="4" piece_type="Blade" mesh="barmace_blade" full_scale="true" length="68.5" weight="2.275" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -32250,7 +32262,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_onehanded_barmace_blade_h1" name="{=}Onehanded Barmace Blade" tier="4" piece_type="Blade" mesh="barmace_blade" full_scale="true" length="68.5" weight="2.2" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -32258,15 +32270,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_onehanded_barmace_blade_h2" name="{=}Onehanded Barmace Blade" tier="4" piece_type="Blade" mesh="barmace_blade" full_scale="true" length="68.5" weight="2.2" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_onehanded_barmace_blade_h3" name="{=}Onehanded Barmace Blade" tier="4" piece_type="Blade" mesh="barmace_blade" full_scale="true" length="68.5" weight="2.2" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_onehanded_barmace_blade_h3" name="{=}Onehanded Barmace Blade" tier="4" piece_type="Blade" mesh="barmace_blade" full_scale="true" length="68.5" weight="2.15" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -36410,7 +36422,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_jamescross_1h_blade_h0" name="{=Yeldur}Cross Head" tier="3" piece_type="Blade" mesh="acrecross_blade" length="33" weight="0.75" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.7" />
+      <Swing damage_type="Blunt" damage_factor="1.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -36419,7 +36431,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_jamescross_1h_blade_h1" name="{=Yeldur}Cross Head" tier="3" piece_type="Blade" mesh="acrecross_blade" length="33" weight="0.75" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.7" />
+      <Swing damage_type="Blunt" damage_factor="1.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -36428,7 +36440,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_jamescross_1h_blade_h2" name="{=Yeldur}Cross Head" tier="3" piece_type="Blade" mesh="acrecross_blade" length="33" weight="0.75" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.8" />
+      <Swing damage_type="Blunt" damage_factor="1.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -36437,7 +36449,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_jamescross_1h_blade_h3" name="{=Yeldur}Cross Head" tier="3" piece_type="Blade" mesh="acrecross_blade" length="33" weight="0.72" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.8" />
+      <Swing damage_type="Blunt" damage_factor="1.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -37326,22 +37338,22 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_bobs_ballmace_head_h0" name="{=BalanceMe}Bob's Ballmace Head" tier="3" piece_type="Blade" mesh="bobs_ballmace_head" length="24.8" weight="0.75" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
   </CraftingPiece>
   <CraftingPiece id="crpg_bobs_ballmace_head_h1" name="{=BalanceMe}Bob's Ballmace Head" tier="3" piece_type="Blade" mesh="bobs_ballmace_head" length="24.8" weight="0.75" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
   </CraftingPiece>
   <CraftingPiece id="crpg_bobs_ballmace_head_h2" name="{=BalanceMe}Bob's Ballmace Head" tier="3" piece_type="Blade" mesh="bobs_ballmace_head" length="24.8" weight="0.75" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
   </CraftingPiece>
   <CraftingPiece id="crpg_bobs_ballmace_head_h3" name="{=BalanceMe}Bob's Ballmace Head" tier="3" piece_type="Blade" mesh="bobs_ballmace_head" length="24.8" weight="0.65" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
   </CraftingPiece>
   <CraftingPiece id="crpg_bobs_ballmace_pommel_h0" name="{=BalanceMe}Bob's Ballmace Dummy Pommel" tier="3" piece_type="Pommel" mesh="" culture="Culture.empire" full_scale="true" length="0" weight="1.0">

--- a/crafting_templates.xml
+++ b/crafting_templates.xml
@@ -6954,14 +6954,6 @@
       <UsablePiece piece_id="crpg_spiked_polehammer_handle_h1" />
       <UsablePiece piece_id="crpg_spiked_polehammer_handle_h2" />
       <UsablePiece piece_id="crpg_spiked_polehammer_handle_h3" />
-      <UsablePiece piece_id="crpg_spiked_polehammer_knockdown_blade_h0" />
-      <UsablePiece piece_id="crpg_spiked_polehammer_knockdown_blade_h1" />
-      <UsablePiece piece_id="crpg_spiked_polehammer_knockdown_blade_h2" />
-      <UsablePiece piece_id="crpg_spiked_polehammer_knockdown_blade_h3" />
-      <UsablePiece piece_id="crpg_spiked_polehammer_knockdown_handle_h0" />
-      <UsablePiece piece_id="crpg_spiked_polehammer_knockdown_handle_h1" />
-      <UsablePiece piece_id="crpg_spiked_polehammer_knockdown_handle_h2" />
-      <UsablePiece piece_id="crpg_spiked_polehammer_knockdown_handle_h3" />
       <UsablePiece piece_id="crpg_bec_de_corbin_handle_h0" />
       <UsablePiece piece_id="crpg_bec_de_corbin_handle_h1" />
       <UsablePiece piece_id="crpg_bec_de_corbin_handle_h2" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -1,72 +1,72 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
-  <CraftedItem id="crpg_french_voulge_v2_h0" name="{=kaikaikai}French Voulge" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_french_voulge_v3_h0" name="{=kaikaikai}French Voulge" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_french_voulge_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_french_voulge_handle_h0" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_french_voulge_v2_h1" name="{=kaikaikai}French Voulge +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_french_voulge_v3_h1" name="{=kaikaikai}French Voulge +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_french_voulge_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_french_voulge_handle_h1" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_french_voulge_v2_h2" name="{=kaikaikai}French Voulge +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_french_voulge_v3_h2" name="{=kaikaikai}French Voulge +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_french_voulge_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_french_voulge_handle_h2" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_french_voulge_v2_h3" name="{=kaikaikai}French Voulge +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_french_voulge_v3_h3" name="{=kaikaikai}French Voulge +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_french_voulge_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_french_voulge_handle_h3" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_glaive_v5_h0" name="{=kaikaikai}Burgundian Glaive" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_glaive_v6_h0" name="{=kaikaikai}Burgundian Glaive" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_glaive_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_glaive_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_glaive_v5_h1" name="{=kaikaikai}Burgundian Glaive +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_glaive_v6_h1" name="{=kaikaikai}Burgundian Glaive +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_glaive_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_glaive_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_glaive_v5_h2" name="{=kaikaikai}Burgundian Glaive +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_glaive_v6_h2" name="{=kaikaikai}Burgundian Glaive +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_glaive_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_glaive_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_glaive_v5_h3" name="{=kaikaikai}Burgundian Glaive +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_glaive_v6_h3" name="{=kaikaikai}Burgundian Glaive +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_glaive_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_glaive_handle_h3" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_poleaxe_v6_h0" name="{=kaikaikai}Burgundian Poleaxe" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_poleaxe_v7_h0" name="{=kaikaikai}Burgundian Poleaxe" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_poleaxe_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_poleaxe_handle_h0" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_poleaxe_v6_h1" name="{=kaikaikai}Burgundian Poleaxe +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_poleaxe_v7_h1" name="{=kaikaikai}Burgundian Poleaxe +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_poleaxe_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_poleaxe_handle_h1" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_poleaxe_v6_h2" name="{=kaikaikai}Burgundian Poleaxe +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_poleaxe_v7_h2" name="{=kaikaikai}Burgundian Poleaxe +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_poleaxe_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_poleaxe_handle_h2" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_poleaxe_v6_h3" name="{=kaikaikai}Burgundian Poleaxe +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_poleaxe_v7_h3" name="{=kaikaikai}Burgundian Poleaxe +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_poleaxe_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_poleaxe_handle_h3" Type="Handle" scale_factor="125" />
@@ -96,25 +96,25 @@
       <Piece id="crpg_simple_poleaxe_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bec_de_corbin_v4_h0" name="{=kaikaikai}Bec De Corbin" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_bec_de_corbin_v5_h0" name="{=kaikaikai}Bec De Corbin" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_bec_de_corbin_blade_h0" Type="Blade" scale_factor="98" />
       <Piece id="crpg_bec_de_corbin_handle_h0" Type="Handle" scale_factor="98" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bec_de_corbin_v4_h1" name="{=kaikaikai}Bec De Corbin +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_bec_de_corbin_v5_h1" name="{=kaikaikai}Bec De Corbin +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_bec_de_corbin_blade_h1" Type="Blade" scale_factor="98" />
       <Piece id="crpg_bec_de_corbin_handle_h1" Type="Handle" scale_factor="98" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bec_de_corbin_v4_h2" name="{=kaikaikai}Bec De Corbin +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_bec_de_corbin_v5_h2" name="{=kaikaikai}Bec De Corbin +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_bec_de_corbin_blade_h2" Type="Blade" scale_factor="98" />
       <Piece id="crpg_bec_de_corbin_handle_h2" Type="Handle" scale_factor="98" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bec_de_corbin_v4_h3" name="{=kaikaikai}Bec De Corbin +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_bec_de_corbin_v5_h3" name="{=kaikaikai}Bec De Corbin +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_bec_de_corbin_blade_h3" Type="Blade" scale_factor="98" />
       <Piece id="crpg_bec_de_corbin_handle_h3" Type="Handle" scale_factor="98" />
@@ -712,25 +712,25 @@
       <Piece id="crpg_long_maul_handle_h3" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_long_maul_v2_h0" name="{=}Great Long Maul" crafting_template="crpg_TwoHandedPolearm" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_great_long_maul_v3_h0" name="{=}Great Long Maul" crafting_template="crpg_TwoHandedPolearm" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_great_long_maul_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_great_long_maul_handle_h0" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_long_maul_v2_h1" name="{=}Great Long Maul +1" crafting_template="crpg_TwoHandedPolearm" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_great_long_maul_v3_h1" name="{=}Great Long Maul +1" crafting_template="crpg_TwoHandedPolearm" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_great_long_maul_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_great_long_maul_handle_h1" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_long_maul_v2_h2" name="{=}Great Long Maul +2" crafting_template="crpg_TwoHandedPolearm" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_great_long_maul_v3_h2" name="{=}Great Long Maul +2" crafting_template="crpg_TwoHandedPolearm" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_great_long_maul_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_great_long_maul_handle_h2" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_long_maul_v2_h3" name="{=}Great Long Maul +3" crafting_template="crpg_TwoHandedPolearm" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_great_long_maul_v3_h3" name="{=}Great Long Maul +3" crafting_template="crpg_TwoHandedPolearm" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_great_long_maul_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_great_long_maul_handle_h3" Type="Handle" scale_factor="165" />
@@ -912,25 +912,25 @@
       <Piece id="crpg_barmace_handle_h3" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_awlpike_v4_h0" name="{=}Awlpike" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_awlpike_v5_h0" name="{=}Awlpike" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_awlpike_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_awlpike_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_awlpike_v4_h1" name="{=}Awlpike +1" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_awlpike_v5_h1" name="{=}Awlpike +1" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_awlpike_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_awlpike_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_awlpike_v4_h2" name="{=}Awlpike +2" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_awlpike_v5_h2" name="{=}Awlpike +2" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_awlpike_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_awlpike_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_awlpike_v4_h3" name="{=}Awlpike +3" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_awlpike_v5_h3" name="{=}Awlpike +3" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_awlpike_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_awlpike_handle_h3" Type="Handle" scale_factor="100" />
@@ -8444,7 +8444,7 @@
       <Piece id="crpg_long_glaive_pommel_h3" Type="Pommel" scale_factor="97" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_menavlion_v5_h0" name="{=kaikaikai}Fine Steel Menavlion" crafting_template="crpg_Polearm_2dswing" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_menavlion_v6_h0" name="{=kaikaikai}Fine Steel Menavlion" crafting_template="crpg_Polearm_2dswing" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_menavlion_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fine_steel_menavlion_guard_h0" Type="Guard" scale_factor="100" />
@@ -8452,7 +8452,7 @@
       <Piece id="crpg_fine_steel_menavlion_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_menavlion_v5_h1" name="{=kaikaikai}Fine Steel Menavlion +1" crafting_template="crpg_Polearm_2dswing" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_menavlion_v6_h1" name="{=kaikaikai}Fine Steel Menavlion +1" crafting_template="crpg_Polearm_2dswing" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_menavlion_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fine_steel_menavlion_guard_h1" Type="Guard" scale_factor="100" />
@@ -8460,7 +8460,7 @@
       <Piece id="crpg_fine_steel_menavlion_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_menavlion_v5_h2" name="{=kaikaikai}Fine Steel Menavlion +2" crafting_template="crpg_Polearm_2dswing" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_menavlion_v6_h2" name="{=kaikaikai}Fine Steel Menavlion +2" crafting_template="crpg_Polearm_2dswing" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_menavlion_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fine_steel_menavlion_guard_h2" Type="Guard" scale_factor="100" />
@@ -8468,7 +8468,7 @@
       <Piece id="crpg_fine_steel_menavlion_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_menavlion_v5_h3" name="{=kaikaikai}Fine Steel Menavlion +3" crafting_template="crpg_Polearm_2dswing" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_menavlion_v6_h3" name="{=kaikaikai}Fine Steel Menavlion +3" crafting_template="crpg_Polearm_2dswing" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_menavlion_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fine_steel_menavlion_guard_h3" Type="Guard" scale_factor="100" />
@@ -8476,7 +8476,7 @@
       <Piece id="crpg_fine_steel_menavlion_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_early_halberd_v4_h0" name="{=kaikaikai}Voulge" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_early_halberd_v3_h0" name="{=kaikaikai}Voulge" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_early_halberd_blade_h0" Type="Blade" scale_factor="99" />
       <Piece id="crpg_early_halberd_guard_h0" Type="Guard" scale_factor="100" />
@@ -8484,7 +8484,7 @@
       <Piece id="crpg_early_halberd_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_early_halberd_v4_h1" name="{=kaikaikai}Voulge +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_early_halberd_v3_h1" name="{=kaikaikai}Voulge +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_early_halberd_blade_h1" Type="Blade" scale_factor="99" />
       <Piece id="crpg_early_halberd_guard_h1" Type="Guard" scale_factor="100" />
@@ -8492,7 +8492,7 @@
       <Piece id="crpg_early_halberd_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_early_halberd_v4_h2" name="{=kaikaikai}Voulge +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_early_halberd_v3_h2" name="{=kaikaikai}Voulge +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_early_halberd_blade_h2" Type="Blade" scale_factor="99" />
       <Piece id="crpg_early_halberd_guard_h2" Type="Guard" scale_factor="100" />
@@ -8500,7 +8500,7 @@
       <Piece id="crpg_early_halberd_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_early_halberd_v4_h3" name="{=kaikaikai}Voulge +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_early_halberd_v3_h3" name="{=kaikaikai}Voulge +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_early_halberd_blade_h3" Type="Blade" scale_factor="99" />
       <Piece id="crpg_early_halberd_guard_h3" Type="Guard" scale_factor="100" />
@@ -8572,7 +8572,7 @@
       <Piece id="crpg_polesword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_glaive_v3_h0" name="{=kaikaikai}Glaive" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_glaive_v4_h0" name="{=kaikaikai}Glaive" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_glaive_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_glaive_guard_h0" Type="Guard" scale_factor="100" />
@@ -8580,7 +8580,7 @@
       <Piece id="crpg_glaive_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_glaive_v3_h1" name="{=kaikaikai}Glaive +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_glaive_v4_h1" name="{=kaikaikai}Glaive +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_glaive_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_glaive_guard_h1" Type="Guard" scale_factor="100" />
@@ -8588,7 +8588,7 @@
       <Piece id="crpg_glaive_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_glaive_v3_h2" name="{=kaikaikai}Glaive +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_glaive_v4_h2" name="{=kaikaikai}Glaive +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_glaive_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_glaive_guard_h2" Type="Guard" scale_factor="100" />
@@ -8596,7 +8596,7 @@
       <Piece id="crpg_glaive_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_glaive_v3_h3" name="{=kaikaikai}Glaive +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_glaive_v4_h3" name="{=kaikaikai}Glaive +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_glaive_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_glaive_guard_h3" Type="Guard" scale_factor="100" />
@@ -8668,7 +8668,7 @@
       <Piece id="crpg_warrazor_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v5_h0" name="{=Yeldur}Billhook" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v6_h0" name="{=Yeldur}Billhook" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h0" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h0" Type="Guard" scale_factor="100" />
@@ -8676,7 +8676,7 @@
       <Piece id="crpg_billhook_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v5_h1" name="{=Yeldur}Billhook +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v6_h1" name="{=Yeldur}Billhook +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h1" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h1" Type="Guard" scale_factor="100" />
@@ -8684,7 +8684,7 @@
       <Piece id="crpg_billhook_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v5_h2" name="{=Yeldur}Billhook +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v6_h2" name="{=Yeldur}Billhook +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h2" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h2" Type="Guard" scale_factor="100" />
@@ -8692,7 +8692,7 @@
       <Piece id="crpg_billhook_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v5_h3" name="{=Yeldur}Billhook +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v6_h3" name="{=Yeldur}Billhook +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h3" Type="Blade" scale_factor="155" />
       <Piece id="crpg_billhook_guard_h3" Type="Guard" scale_factor="100" />
@@ -9080,7 +9080,7 @@
       <Piece id="crpg_steel_tipped_hooked_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h0" name="{=bwXACVOb}Fine Steel Leaf Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v3_h0" name="{=bwXACVOb}Fine Steel Leaf Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h0" Type="Guard" scale_factor="100" />
@@ -9088,7 +9088,7 @@
       <Piece id="crpg_fine_steel_leaf_spear_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h1" name="{=bwXACVOb}Fine Steel Leaf Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v3_h1" name="{=bwXACVOb}Fine Steel Leaf Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h1" Type="Guard" scale_factor="100" />
@@ -9096,7 +9096,7 @@
       <Piece id="crpg_fine_steel_leaf_spear_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h2" name="{=bwXACVOb}Fine Steel Leaf Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v3_h2" name="{=bwXACVOb}Fine Steel Leaf Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h2" Type="Guard" scale_factor="100" />
@@ -9104,7 +9104,7 @@
       <Piece id="crpg_fine_steel_leaf_spear_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h3" name="{=bwXACVOb}Fine Steel Leaf Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v3_h3" name="{=bwXACVOb}Fine Steel Leaf Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h3" Type="Guard" scale_factor="100" />
@@ -9676,25 +9676,25 @@
       <Piece id="crpg_drilled_two_handed_axe_handle_h3" Type="Handle" scale_factor="78" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_long_bardiche_v3_h0" name="{=kaikaikai}Great Long Bardiche" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_great_long_bardiche_v4_h0" name="{=kaikaikai}Great Long Bardiche" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_great_long_bardiche_blade_h0" Type="Blade" scale_factor="99" />
       <Piece id="crpg_great_long_bardiche_handle_h0" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_long_bardiche_v3_h1" name="{=kaikaikai}Great Long Bardiche +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_great_long_bardiche_v4_h1" name="{=kaikaikai}Great Long Bardiche +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_great_long_bardiche_blade_h1" Type="Blade" scale_factor="99" />
       <Piece id="crpg_great_long_bardiche_handle_h1" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_long_bardiche_v3_h2" name="{=kaikaikai}Great Long Bardiche +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_great_long_bardiche_v4_h2" name="{=kaikaikai}Great Long Bardiche +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_great_long_bardiche_blade_h2" Type="Blade" scale_factor="99" />
       <Piece id="crpg_great_long_bardiche_handle_h2" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_long_bardiche_v3_h3" name="{=kaikaikai}Great Long Bardiche +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_great_long_bardiche_v4_h3" name="{=kaikaikai}Great Long Bardiche +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_great_long_bardiche_blade_h3" Type="Blade" scale_factor="99" />
       <Piece id="crpg_great_long_bardiche_handle_h3" Type="Handle" scale_factor="150" />
@@ -10900,7 +10900,7 @@
       <Piece id="crpg_bo_staff_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bludgeon_staff_v3_h0" name="{=kaikaikai}Bludgeon Staff" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bludgeon_staff_v4_h0" name="{=kaikaikai}Bludgeon Staff" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bludgeon_staff_blade_h0" Type="Blade" />
       <Piece id="crpg_bludgeon_staff_guard_h0" Type="Guard" />
@@ -10908,7 +10908,7 @@
       <Piece id="crpg_bludgeon_staff_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bludgeon_staff_v3_h1" name="{=kaikaikai}Bludgeon Staff +1" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bludgeon_staff_v4_h1" name="{=kaikaikai}Bludgeon Staff +1" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bludgeon_staff_blade_h1" Type="Blade" />
       <Piece id="crpg_bludgeon_staff_guard_h1" Type="Guard" />
@@ -10916,7 +10916,7 @@
       <Piece id="crpg_bludgeon_staff_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bludgeon_staff_v3_h2" name="{=kaikaikai}Bludgeon Staff +2" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bludgeon_staff_v4_h2" name="{=kaikaikai}Bludgeon Staff +2" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bludgeon_staff_blade_h2" Type="Blade" />
       <Piece id="crpg_bludgeon_staff_guard_h2" Type="Guard" />
@@ -10924,7 +10924,7 @@
       <Piece id="crpg_bludgeon_staff_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bludgeon_staff_v3_h3" name="{=kaikaikai}Bludgeon Staff +3" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bludgeon_staff_v4_h3" name="{=kaikaikai}Bludgeon Staff +3" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bludgeon_staff_blade_h3" Type="Blade" />
       <Piece id="crpg_bludgeon_staff_guard_h3" Type="Guard" />
@@ -12924,7 +12924,7 @@
       <Piece id="crpg_tanto_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fangtian_ji_v3_h0" name="{=kaikaikai}Fangtian Ji" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_fangtian_ji_v4_h0" name="{=kaikaikai}Fangtian Ji" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fangtian_ji_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fangtian_ji_guard_h0" Type="Guard" scale_factor="110" />
@@ -12932,7 +12932,7 @@
       <Piece id="crpg_fangtian_ji_pommel_h0" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fangtian_ji_v3_h1" name="{=kaikaikai}Fangtian Ji +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_fangtian_ji_v4_h1" name="{=kaikaikai}Fangtian Ji +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fangtian_ji_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fangtian_ji_guard_h1" Type="Guard" scale_factor="110" />
@@ -12940,7 +12940,7 @@
       <Piece id="crpg_fangtian_ji_pommel_h1" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fangtian_ji_v3_h2" name="{=kaikaikai}Fangtian Ji +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_fangtian_ji_v4_h2" name="{=kaikaikai}Fangtian Ji +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fangtian_ji_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fangtian_ji_guard_h2" Type="Guard" scale_factor="110" />
@@ -12948,7 +12948,7 @@
       <Piece id="crpg_fangtian_ji_pommel_h2" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fangtian_ji_v3_h3" name="{=kaikaikai}Fangtian Ji +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_fangtian_ji_v4_h3" name="{=kaikaikai}Fangtian Ji +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fangtian_ji_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fangtian_ji_guard_h3" Type="Guard" scale_factor="110" />
@@ -12988,7 +12988,7 @@
       <Piece id="crpg_jian_pommel_h3" Type="Pommel" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ironrod_v4_h0" name="{=Yeldur}Iron Rod" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_ironrod_v5_h0" name="{=Yeldur}Iron Rod" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_ironrod_blade_h0" Type="Blade" scale_factor="1" />
       <Piece id="crpg_ironrod_guard_h0" Type="Guard" />
@@ -12996,7 +12996,7 @@
       <Piece id="crpg_ironrod_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ironrod_v4_h1" name="{=Yeldur}Iron Rod +1" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_ironrod_v5_h1" name="{=Yeldur}Iron Rod +1" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_ironrod_blade_h1" Type="Blade" scale_factor="1" />
       <Piece id="crpg_ironrod_guard_h1" Type="Guard" />
@@ -13004,7 +13004,7 @@
       <Piece id="crpg_ironrod_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ironrod_v4_h2" name="{=Yeldur}Iron Rod +2" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_ironrod_v5_h2" name="{=Yeldur}Iron Rod +2" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_ironrod_blade_h2" Type="Blade" scale_factor="1" />
       <Piece id="crpg_ironrod_guard_h2" Type="Guard" />
@@ -13012,7 +13012,7 @@
       <Piece id="crpg_ironrod_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ironrod_v4_h3" name="{=Yeldur}Iron Rod +3" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_ironrod_v5_h3" name="{=Yeldur}Iron Rod +3" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_ironrod_blade_h3" Type="Blade" scale_factor="1" />
       <Piece id="crpg_ironrod_guard_h3" Type="Guard" />
@@ -13020,7 +13020,7 @@
       <Piece id="crpg_ironrod_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_german_halberd_v4_h0" name="{=kaikaikai}German Halberd" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_german_halberd_v5_h0" name="{=kaikaikai}German Halberd" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_german_halberd_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_german_halberd_handle_h0" Type="Handle" scale_factor="95" />
@@ -13028,7 +13028,7 @@
       <Piece id="crpg_german_halberd_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_german_halberd_v4_h1" name="{=kaikaikai}German Halberd +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_german_halberd_v5_h1" name="{=kaikaikai}German Halberd +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_german_halberd_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_german_halberd_handle_h1" Type="Handle" scale_factor="95" />
@@ -13036,7 +13036,7 @@
       <Piece id="crpg_german_halberd_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_german_halberd_v4_h2" name="{=kaikaikai}German Halberd +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_german_halberd_v5_h2" name="{=kaikaikai}German Halberd +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_german_halberd_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_german_halberd_handle_h2" Type="Handle" scale_factor="95" />
@@ -13044,7 +13044,7 @@
       <Piece id="crpg_german_halberd_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_german_halberd_v4_h3" name="{=kaikaikai}German Halberd +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_german_halberd_v5_h3" name="{=kaikaikai}German Halberd +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_german_halberd_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_german_halberd_handle_h3" Type="Handle" scale_factor="95" />
@@ -13324,25 +13324,25 @@
       <Piece id="crpg_short_bardiche_handle_h3" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bill_v2_h0" name="{=Yeldur}Bill" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_bill_v3_h0" name="{=Yeldur}Bill" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_bill_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bill_handle_h0" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bill_v2_h1" name="{=Yeldur}Bill +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_bill_v3_h1" name="{=Yeldur}Bill +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_bill_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bill_handle_h1" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bill_v2_h2" name="{=Yeldur}Bill +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_bill_v3_h2" name="{=Yeldur}Bill +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_bill_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bill_handle_h2" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bill_v2_h3" name="{=Yeldur}Bill +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_bill_v3_h3" name="{=Yeldur}Bill +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_bill_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bill_handle_h3" Type="Handle" scale_factor="115" />
@@ -13404,34 +13404,34 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <CraftedItem id="crpg_english_bill_v3_h0" name="{=Salt}English Bill" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_english_bill_v4_h0" name="{=Salt}English Bill" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_english_bill_blade_h0" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_english_bill_handle_h0" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_english_bill_handle_h0" Type="Handle" scale_factor="110" />
       <Piece id="crpg_english_bill_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_english_bill_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_english_bill_v3_h1" name="{=Salt}English Bill +1" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_english_bill_v4_h1" name="{=Salt}English Bill +1" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_english_bill_blade_h1" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_english_bill_handle_h1" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_english_bill_handle_h1" Type="Handle" scale_factor="110" />
       <Piece id="crpg_english_bill_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_english_bill_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_english_bill_v3_h2" name="{=Salt}English Bill +2" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_english_bill_v4_h2" name="{=Salt}English Bill +2" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_english_bill_blade_h2" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_english_bill_handle_h2" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_english_bill_handle_h2" Type="Handle" scale_factor="110" />
       <Piece id="crpg_english_bill_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_english_bill_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_english_bill_v3_h3" name="{=Salt}English Bill +3" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_english_bill_v4_h3" name="{=Salt}English Bill +3" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_english_bill_blade_h3" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_english_bill_handle_h3" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_english_bill_handle_h3" Type="Handle" scale_factor="110" />
       <Piece id="crpg_english_bill_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_english_bill_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
@@ -13724,25 +13724,25 @@
       <Piece id="crpg_karabela_pommel_h3" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_v2_h0" name="{=Salt}Great Long Axe" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v3_h0" name="{=Salt}Great Long Axe" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h0" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_v2_h1" name="{=Salt}Great Long Axe +1" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v3_h1" name="{=Salt}Great Long Axe +1" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h1" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_v2_h2" name="{=Salt}Great Long Axe +2" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v3_h2" name="{=Salt}Great Long Axe +2" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h2" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_v2_h3" name="{=Salt}Great Long Axe +3" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v3_h3" name="{=Salt}Great Long Axe +3" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h3" Type="Handle" scale_factor="165" />
@@ -13988,7 +13988,7 @@
       <Piece id="crpg_strangearmingsword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ancientvoulge_v2_h0" name="{=Yeldur}Ancient Long Voulge" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_ancientvoulge_v3_h0" name="{=Yeldur}Ancient Long Voulge" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_ancientvoulge_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_ancientvoulge_handle_h0" Type="Handle" scale_factor="120" />
@@ -13996,7 +13996,7 @@
       <Piece id="crpg_ancientvoulge_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ancientvoulge_v2_h1" name="{=Yeldur}Ancient Long Voulge +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_ancientvoulge_v3_h1" name="{=Yeldur}Ancient Long Voulge +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_ancientvoulge_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_ancientvoulge_handle_h1" Type="Handle" scale_factor="120" />
@@ -14004,7 +14004,7 @@
       <Piece id="crpg_ancientvoulge_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ancientvoulge_v2_h2" name="{=Yeldur}Ancient Long Voulge +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_ancientvoulge_v3_h2" name="{=Yeldur}Ancient Long Voulge +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_ancientvoulge_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_ancientvoulge_handle_h2" Type="Handle" scale_factor="120" />
@@ -14012,7 +14012,7 @@
       <Piece id="crpg_ancientvoulge_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ancientvoulge_v2_h3" name="{=Yeldur}Ancient Long Voulge +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_ancientvoulge_v3_h3" name="{=Yeldur}Ancient Long Voulge +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_ancientvoulge_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_ancientvoulge_handle_h3" Type="Handle" scale_factor="120" />
@@ -14020,7 +14020,7 @@
       <Piece id="crpg_ancientvoulge_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fabulousvoulge_h0" name="{=Yeldur}Noble Short Voulge" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_fabulousvoulge_v1_h0" name="{=Yeldur}Noble Short Voulge" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_fabulousvoulge_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fabulousvoulge_handle_h0" Type="Handle" scale_factor="110" />
@@ -14028,7 +14028,7 @@
       <Piece id="crpg_fabulousvoulge_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fabulousvoulge_h1" name="{=Yeldur}Noble Short Voulge +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_fabulousvoulge_v1_h1" name="{=Yeldur}Noble Short Voulge +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_fabulousvoulge_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fabulousvoulge_handle_h1" Type="Handle" scale_factor="110" />
@@ -14036,7 +14036,7 @@
       <Piece id="crpg_fabulousvoulge_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fabulousvoulge_h2" name="{=Yeldur}Noble Short Voulge +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_fabulousvoulge_v1_h2" name="{=Yeldur}Noble Short Voulge +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_fabulousvoulge_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fabulousvoulge_handle_h2" Type="Handle" scale_factor="110" />
@@ -14044,7 +14044,7 @@
       <Piece id="crpg_fabulousvoulge_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fabulousvoulge_h3" name="{=Yeldur}Noble Short Voulge +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_fabulousvoulge_v1_h3" name="{=Yeldur}Noble Short Voulge +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_fabulousvoulge_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fabulousvoulge_handle_h3" Type="Handle" scale_factor="110" />
@@ -14508,7 +14508,7 @@
       <Piece id="crpg_templarsword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_at_partisan_v3_h0" name="{=AppleTruce}Partisan" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_at_partisan_v4_h0" name="{=AppleTruce}Partisan" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_at_partisan_blade_h0" Type="Blade" scale_factor="102" />
       <Piece id="crpg_at_partisan_handle_h0" Type="Handle" scale_factor="98" />
@@ -14516,7 +14516,7 @@
       <Piece id="crpg_at_partisan_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_at_partisan_v3_h1" name="{=AppleTruce}Partisan +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_at_partisan_v4_h1" name="{=AppleTruce}Partisan +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_at_partisan_blade_h1" Type="Blade" scale_factor="102" />
       <Piece id="crpg_at_partisan_handle_h1" Type="Handle" scale_factor="98" />
@@ -14524,7 +14524,7 @@
       <Piece id="crpg_at_partisan_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_at_partisan_v3_h2" name="{=AppleTruce}Partisan +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_at_partisan_v4_h2" name="{=AppleTruce}Partisan +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_at_partisan_blade_h2" Type="Blade" scale_factor="102" />
       <Piece id="crpg_at_partisan_handle_h2" Type="Handle" scale_factor="98" />
@@ -14532,7 +14532,7 @@
       <Piece id="crpg_at_partisan_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_at_partisan_v3_h3" name="{=AppleTruce}Partisan +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_at_partisan_v4_h3" name="{=AppleTruce}Partisan +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_at_partisan_blade_h3" Type="Blade" scale_factor="102" />
       <Piece id="crpg_at_partisan_handle_h3" Type="Handle" scale_factor="98" />
@@ -14724,7 +14724,7 @@
       <Piece id="crpg_chankamace_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_celticspear_h0" name="{=BalanceMe}La Tene Spear" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_celticspear_v1_h0" name="{=Yeldur}La Tene Spear" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_celticspear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_celticspear_handle_h0" Type="Handle" scale_factor="80" />
@@ -14732,7 +14732,7 @@
       <Piece id="crpg_celticspear_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_celticspear_h1" name="{=BalanceMe}La Tene Spear +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_celticspear_v1_h1" name="{=Yeldur}La Tene Spear +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_celticspear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_celticspear_handle_h1" Type="Handle" scale_factor="80" />
@@ -14740,7 +14740,7 @@
       <Piece id="crpg_celticspear_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_celticspear_h2" name="{=BalanceMe}La Tene Spear +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_celticspear_v1_h2" name="{=Yeldur}La Tene Spear +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_celticspear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_celticspear_handle_h2" Type="Handle" scale_factor="80" />
@@ -14748,7 +14748,7 @@
       <Piece id="crpg_celticspear_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_celticspear_h3" name="{=BalanceMe}La Tene Spear +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_celticspear_v1_h3" name="{=Yeldur}La Tene Spear +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_celticspear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_celticspear_handle_h3" Type="Handle" scale_factor="80" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -72,25 +72,25 @@
       <Piece id="crpg_burgundian_poleaxe_handle_h3" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_poleaxe_v2_h0" name="{=kaikaikai}Simple Poleaxe" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_simple_poleaxe_v3_h0" name="{=kaikaikai}Simple Poleaxe" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_simple_poleaxe_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_simple_poleaxe_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_poleaxe_v2_h1" name="{=kaikaikai}Simple Poleaxe +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_simple_poleaxe_v3_h1" name="{=kaikaikai}Simple Poleaxe +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_simple_poleaxe_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_simple_poleaxe_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_poleaxe_v2_h2" name="{=kaikaikai}Simple Poleaxe +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_simple_poleaxe_v3_h2" name="{=kaikaikai}Simple Poleaxe +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_simple_poleaxe_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_simple_poleaxe_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_poleaxe_v2_h3" name="{=kaikaikai}Simple Poleaxe +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_simple_poleaxe_v3_h3" name="{=kaikaikai}Simple Poleaxe +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_simple_poleaxe_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_simple_poleaxe_handle_h3" Type="Handle" scale_factor="100" />
@@ -120,52 +120,28 @@
       <Piece id="crpg_bec_de_corbin_handle_h3" Type="Handle" scale_factor="98" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v7_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v7_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v7_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v7_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h3" Type="Handle" scale_factor="100" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
-    <Pieces>
-      <Piece id="crpg_spiked_polehammer_knockdown_blade_h0" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_spiked_polehammer_knockdown_handle_h0" Type="Handle" scale_factor="100" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
-    <Pieces>
-      <Piece id="crpg_spiked_polehammer_knockdown_blade_h1" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_spiked_polehammer_knockdown_handle_h1" Type="Handle" scale_factor="100" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
-    <Pieces>
-      <Piece id="crpg_spiked_polehammer_knockdown_blade_h2" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_spiked_polehammer_knockdown_handle_h2" Type="Handle" scale_factor="100" />
-    </Pieces>
-  </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v6_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
-    <Pieces>
-      <Piece id="crpg_spiked_polehammer_knockdown_blade_h3" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_spiked_polehammer_knockdown_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_warhammer_v3_h0" name="{=}Warhammer" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
@@ -8412,7 +8388,7 @@
       <Piece id="crpg_mamluke_lance_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_glaive_v4_h0" name="{=kaikaikai}Long Glaive" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_glaive_v5_h0" name="{=kaikaikai}Long Glaive" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_glaive_blade_h0" Type="Blade" scale_factor="97" />
       <Piece id="crpg_long_glaive_guard_h0" Type="Guard" scale_factor="97" />
@@ -8420,7 +8396,7 @@
       <Piece id="crpg_long_glaive_pommel_h0" Type="Pommel" scale_factor="97" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_glaive_v4_h1" name="{=kaikaikai}Long Glaive +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_glaive_v5_h1" name="{=kaikaikai}Long Glaive +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_glaive_blade_h1" Type="Blade" scale_factor="97" />
       <Piece id="crpg_long_glaive_guard_h1" Type="Guard" scale_factor="97" />
@@ -8428,7 +8404,7 @@
       <Piece id="crpg_long_glaive_pommel_h1" Type="Pommel" scale_factor="97" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_glaive_v4_h2" name="{=kaikaikai}Long Glaive +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_glaive_v5_h2" name="{=kaikaikai}Long Glaive +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_glaive_blade_h2" Type="Blade" scale_factor="97" />
       <Piece id="crpg_long_glaive_guard_h2" Type="Guard" scale_factor="97" />
@@ -8436,7 +8412,7 @@
       <Piece id="crpg_long_glaive_pommel_h2" Type="Pommel" scale_factor="97" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_glaive_v4_h3" name="{=kaikaikai}Long Glaive +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_glaive_v5_h3" name="{=kaikaikai}Long Glaive +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_glaive_blade_h3" Type="Blade" scale_factor="97" />
       <Piece id="crpg_long_glaive_guard_h3" Type="Guard" scale_factor="97" />
@@ -8508,7 +8484,7 @@
       <Piece id="crpg_early_halberd_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rhomphaia_v4_h0" name="{=kaikaikai}Rhomphaia" crafting_template="crpg_TwoHandedPolearm" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_rhomphaia_v5_h0" name="{=kaikaikai}Rhomphaia" crafting_template="crpg_TwoHandedPolearm" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_rhomphaia_blade_h0" Type="Blade" scale_factor="105" />
       <Piece id="crpg_rhomphaia_guard_h0" Type="Guard" scale_factor="90" />
@@ -8516,7 +8492,7 @@
       <Piece id="crpg_rhomphaia_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rhomphaia_v4_h1" name="{=kaikaikai}Rhomphaia +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_rhomphaia_v5__h1" name="{=kaikaikai}Rhomphaia +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_rhomphaia_blade_h1" Type="Blade" scale_factor="105" />
       <Piece id="crpg_rhomphaia_guard_h1" Type="Guard" scale_factor="90" />
@@ -8524,7 +8500,7 @@
       <Piece id="crpg_rhomphaia_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rhomphaia_v4_h2" name="{=kaikaikai}Rhomphaia +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_rhomphaia_v5__h2" name="{=kaikaikai}Rhomphaia +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_rhomphaia_blade_h2" Type="Blade" scale_factor="105" />
       <Piece id="crpg_rhomphaia_guard_h2" Type="Guard" scale_factor="90" />
@@ -8532,7 +8508,7 @@
       <Piece id="crpg_rhomphaia_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rhomphaia_v4_h3" name="{=kaikaikai}Rhomphaia +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_rhomphaia_v5__h3" name="{=kaikaikai}Rhomphaia +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_rhomphaia_blade_h3" Type="Blade" scale_factor="105" />
       <Piece id="crpg_rhomphaia_guard_h3" Type="Guard" scale_factor="90" />
@@ -8604,7 +8580,7 @@
       <Piece id="crpg_glaive_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_menavlion_v3_h0" name="{=kaikaikai}Menavlion" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_menavlion_v4_h0" name="{=kaikaikai}Menavlion" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_menavlion_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_menavlion_guard_h0" Type="Guard" scale_factor="100" />
@@ -8612,7 +8588,7 @@
       <Piece id="crpg_menavlion_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_menavlion_v3_h1" name="{=kaikaikai}Menavlion +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_menavlion_v4_h1" name="{=kaikaikai}Menavlion +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_menavlion_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_menavlion_guard_h1" Type="Guard" scale_factor="100" />
@@ -8620,7 +8596,7 @@
       <Piece id="crpg_menavlion_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_menavlion_v3_h2" name="{=kaikaikai}Menavlion +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_menavlion_v4_h2" name="{=kaikaikai}Menavlion +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_menavlion_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_menavlion_guard_h2" Type="Guard" scale_factor="100" />
@@ -8628,7 +8604,7 @@
       <Piece id="crpg_menavlion_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_menavlion_v3_h3" name="{=kaikaikai}Menavlion +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_menavlion_v4_h3" name="{=kaikaikai}Menavlion +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_menavlion_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_menavlion_guard_h3" Type="Guard" scale_factor="100" />
@@ -8636,7 +8612,7 @@
       <Piece id="crpg_menavlion_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warrazor_v4_h0" name="{=kaikaikai}Warrazor" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_warrazor_v5_h0" name="{=kaikaikai}Warrazor" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_warrazor_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_warrazor_guard_h0" Type="Guard" scale_factor="100" />
@@ -8644,7 +8620,7 @@
       <Piece id="crpg_warrazor_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warrazor_v4_h1" name="{=kaikaikai}Warrazor +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_warrazor_v5_h1" name="{=kaikaikai}Warrazor +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_warrazor_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_warrazor_guard_h1" Type="Guard" scale_factor="100" />
@@ -8652,7 +8628,7 @@
       <Piece id="crpg_warrazor_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warrazor_v4_h2" name="{=kaikaikai}Warrazor +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_warrazor_v5_h2" name="{=kaikaikai}Warrazor +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_warrazor_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_warrazor_guard_h2" Type="Guard" scale_factor="100" />
@@ -8660,7 +8636,7 @@
       <Piece id="crpg_warrazor_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warrazor_v4_h3" name="{=kaikaikai}Warrazor +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_warrazor_v5_h3" name="{=kaikaikai}Warrazor +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_warrazor_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_warrazor_guard_h3" Type="Guard" scale_factor="100" />
@@ -9020,7 +8996,7 @@
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h0" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_long_thamaskene_tipped_spear_handle_h0" Type="Handle" scale_factor="115" />
+      <Piece id="crpg_long_thamaskene_tipped_spear_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
@@ -9028,7 +9004,7 @@
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h1" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_long_thamaskene_tipped_spear_handle_h1" Type="Handle" scale_factor="115" />
+      <Piece id="crpg_long_thamaskene_tipped_spear_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
@@ -9036,7 +9012,7 @@
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h2" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_long_thamaskene_tipped_spear_handle_h2" Type="Handle" scale_factor="115" />
+      <Piece id="crpg_long_thamaskene_tipped_spear_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
@@ -9044,7 +9020,7 @@
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h3" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_long_thamaskene_tipped_spear_handle_h3" Type="Handle" scale_factor="115" />
+      <Piece id="crpg_long_thamaskene_tipped_spear_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
@@ -9700,25 +9676,25 @@
       <Piece id="crpg_great_long_bardiche_handle_h3" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_bardiche_v4_h0" name="{=Salt}Long Bardiche" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_bardiche_v5_h0" name="{=Salt}Long Bardiche" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_bardiche_blade_h0" Type="Blade" scale_factor="85" />
       <Piece id="crpg_long_bardiche_handle_h0" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_bardiche_v4_h1" name="{=Salt}Long Bardiche +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_bardiche_v5_h1" name="{=Salt}Long Bardiche +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_bardiche_blade_h1" Type="Blade" scale_factor="85" />
       <Piece id="crpg_long_bardiche_handle_h1" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_bardiche_v4_h2" name="{={=Salt}Long Bardiche +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_bardiche_v5_h2" name="{={=Salt}Long Bardiche +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_bardiche_blade_h2" Type="Blade" scale_factor="85" />
       <Piece id="crpg_long_bardiche_handle_h2" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_bardiche_v4_h3" name="{={=Salt}Long Bardiche +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_bardiche_v5_h3" name="{={=Salt}Long Bardiche +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_bardiche_blade_h3" Type="Blade" scale_factor="85" />
       <Piece id="crpg_long_bardiche_handle_h3" Type="Handle" scale_factor="135" />
@@ -12200,7 +12176,7 @@
       <Piece id="crpg_tetsubo_handle_h3" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_podao_v3_h0" name="{=kaikaikai}Podao" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_podao_v4_h0" name="{=kaikaikai}Podao" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_pudao_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_pudao_guard_h0" Type="Guard" scale_factor="100" />
@@ -12208,7 +12184,7 @@
       <Piece id="crpg_pudao_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_podao_v3_h1" name="{=kaikaikai}Podao +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_podao_v4_h1" name="{=kaikaikai}Podao +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_pudao_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_pudao_guard_h1" Type="Guard" scale_factor="100" />
@@ -12216,7 +12192,7 @@
       <Piece id="crpg_pudao_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_podao_v3_h2" name="{=kaikaikai}Podao +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_podao_v4_h2" name="{=kaikaikai}Podao +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_pudao_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_pudao_guard_h2" Type="Guard" scale_factor="100" />
@@ -12224,7 +12200,7 @@
       <Piece id="crpg_pudao_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_podao_v3_h3" name="{=kaikaikai}Podao +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_podao_v4_h3" name="{=kaikaikai}Podao +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_pudao_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_pudao_guard_h3" Type="Guard" scale_factor="100" />
@@ -12668,25 +12644,25 @@
       <Piece id="crpg_meowdao_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_Norse_Battle_Axe_v2_h0" name="{=kaikaikai}Norse Battle Axe" crafting_template="crpg_TwoHandedPolearm" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_Norse_Battle_Axe_v3_h0" name="{=kaikaikai}Norse Battle Axe" crafting_template="crpg_TwoHandedPolearm" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_meowaxe_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_meowaxe_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_Norse_Battle_Axe_v2_h1" name="{=kaikaikai}Norse Battle Axe +1" crafting_template="crpg_TwoHandedPolearm" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_Norse_Battle_Axe_v3_h1" name="{=kaikaikai}Norse Battle Axe +1" crafting_template="crpg_TwoHandedPolearm" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_meowaxe_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_meowaxe_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_Norse_Battle_Axe_v2_h2" name="{=kaikaikai}Norse Battle Axe +2" crafting_template="crpg_TwoHandedPolearm" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_Norse_Battle_Axe_v3_h2" name="{=kaikaikai}Norse Battle Axe +2" crafting_template="crpg_TwoHandedPolearm" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_meowaxe_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_meowaxe_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_Norse_Battle_Axe_v2_h3" name="{=kaikaikai}Norse Battle Axe +3" crafting_template="crpg_TwoHandedPolearm" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_Norse_Battle_Axe_v3_h3" name="{=kaikaikai}Norse Battle Axe +3" crafting_template="crpg_TwoHandedPolearm" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_meowaxe_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_meowaxe_handle_h3" Type="Handle" scale_factor="100" />
@@ -13300,25 +13276,25 @@
       <Piece id="crpg_candycane_1h_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_bardiche_v1_h0" name="{=Salt}Short Bardiche" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_short_bardiche_v2_h0" name="{=Salt}Short Bardiche" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_bardiche_blade_h0" Type="Blade" scale_factor="70" />
       <Piece id="crpg_short_bardiche_handle_h0" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_bardiche_v1_h1" name="{=Salt}Short Bardiche +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_short_bardiche_v2_h1" name="{=Salt}Short Bardiche +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_bardiche_blade_h1" Type="Blade" scale_factor="70" />
       <Piece id="crpg_short_bardiche_handle_h1" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_bardiche_v1_h2" name="{=Salt}Short Bardiche +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_short_bardiche_v2_h2" name="{=Salt}Short Bardiche +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_bardiche_blade_h2" Type="Blade" scale_factor="70" />
       <Piece id="crpg_short_bardiche_handle_h2" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_bardiche_v1_h3" name="{=Salt}Short Bardiche +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_short_bardiche_v2_h3" name="{=Salt}Short Bardiche +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_bardiche_blade_h3" Type="Blade" scale_factor="70" />
       <Piece id="crpg_short_bardiche_handle_h3" Type="Handle" scale_factor="120" />
@@ -13500,7 +13476,7 @@
       <Piece id="crpg_black_longdagger_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_swiss_halberd_v2_h0" name="{=Salt}Swiss Halberd" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_swiss_halberd_v3_h0" name="{=Salt}Swiss Halberd" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_swiss_halberd_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_swiss_halberd_handle_h0" Type="Handle" scale_factor="100" />
@@ -13508,7 +13484,7 @@
       <Piece id="crpg_swiss_halberd_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_swiss_halberd_v2_h1" name="{=Salt}Swiss Halberd +1" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_swiss_halberd_v3_h1" name="{=Salt}Swiss Halberd +1" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_swiss_halberd_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_swiss_halberd_handle_h1" Type="Handle" scale_factor="100" />
@@ -13516,7 +13492,7 @@
       <Piece id="crpg_swiss_halberd_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_swiss_halberd_v2_h2" name="{=Salt}Swiss Halberd +2" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_swiss_halberd_v3_h2" name="{=Salt}Swiss Halberd +2" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_swiss_halberd_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_swiss_halberd_handle_h2" Type="Handle" scale_factor="100" />
@@ -13524,7 +13500,7 @@
       <Piece id="crpg_swiss_halberd_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_swiss_halberd_v2_h3" name="{=Salt}Swiss Halberd +3" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_swiss_halberd_v3_h3" name="{=Salt}Swiss Halberd +3" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_swiss_halberd_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_swiss_halberd_handle_h3" Type="Handle" scale_factor="100" />
@@ -14020,7 +13996,7 @@
       <Piece id="crpg_ancientvoulge_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fabulousvoulge_v1_h0" name="{=Yeldur}Noble Short Voulge" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_fabulousvoulge_v2_h0" name="{=Yeldur}Noble Short Voulge" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_fabulousvoulge_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fabulousvoulge_handle_h0" Type="Handle" scale_factor="110" />
@@ -14028,7 +14004,7 @@
       <Piece id="crpg_fabulousvoulge_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fabulousvoulge_v1_h1" name="{=Yeldur}Noble Short Voulge +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_fabulousvoulge_v2_h1" name="{=Yeldur}Noble Short Voulge +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_fabulousvoulge_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fabulousvoulge_handle_h1" Type="Handle" scale_factor="110" />
@@ -14036,7 +14012,7 @@
       <Piece id="crpg_fabulousvoulge_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fabulousvoulge_v1_h2" name="{=Yeldur}Noble Short Voulge +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_fabulousvoulge_v2_h2" name="{=Yeldur}Noble Short Voulge +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_fabulousvoulge_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fabulousvoulge_handle_h2" Type="Handle" scale_factor="110" />
@@ -14044,7 +14020,7 @@
       <Piece id="crpg_fabulousvoulge_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fabulousvoulge_v1_h3" name="{=Yeldur}Noble Short Voulge +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_fabulousvoulge_v2_h3" name="{=Yeldur}Noble Short Voulge +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_fabulousvoulge_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fabulousvoulge_handle_h3" Type="Handle" scale_factor="110" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -168,49 +168,49 @@
       <Piece id="crpg_spiked_polehammer_knockdown_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warhammer_v2_h0" name="{=}Warhammer" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_warhammer_v3_h0" name="{=}Warhammer" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_warhammer_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_warhammer_handle_h0" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warhammer_v2_h1" name="{=}Warhammer +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_warhammer_v3_h1" name="{=}Warhammer +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_warhammer_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_warhammer_handle_h1" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warhammer_v2_h2" name="{=}Warhammer +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_warhammer_v3_h2" name="{=}Warhammer +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_warhammer_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_warhammer_handle_h2" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warhammer_v2_h3" name="{=}Warhammer +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_warhammer_v3_h3" name="{=}Warhammer +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_warhammer_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_warhammer_handle_h3" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_military_hammer_v2_h0" name="{=}Military Hammer" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_military_hammer_v3_h0" name="{=}Military Hammer" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_military_hammer_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_military_hammer_handle_h0" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_military_hammer_v2_h1" name="{=}Military Hammer +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_military_hammer_v3_h1" name="{=}Military Hammer +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_military_hammer_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_military_hammer_handle_h1" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_military_hammer_v2_h2" name="{=}Military Hammer +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_military_hammer_v3_h2" name="{=}Military Hammer +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_military_hammer_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_military_hammer_handle_h2" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_military_hammer_v2_h3" name="{=}Military Hammer +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_military_hammer_v3_h3" name="{=}Military Hammer +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_military_hammer_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_military_hammer_handle_h3" Type="Handle" scale_factor="135" />
@@ -240,49 +240,49 @@
       <Piece id="crpg_heavy_goedendag_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_medium_goedendag_v2_h0" name="{=}Medium Goedendag" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_medium_goedendag_v3_h0" name="{=}Medium Goedendag" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_medium_goedendag_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_medium_goedendag_handle_h0" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_medium_goedendag_v2_h1" name="{=}Medium Goedendag +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_medium_goedendag_v3_h1" name="{=}Medium Goedendag +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_medium_goedendag_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_medium_goedendag_handle_h1" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_medium_goedendag_v2_h2" name="{=}Medium Goedendag +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_medium_goedendag_v3_h2" name="{=}Medium Goedendag +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_medium_goedendag_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_medium_goedendag_handle_h2" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_medium_goedendag_v2_h3" name="{=}Medium Goedendag +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_medium_goedendag_v3_h3" name="{=}Medium Goedendag +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_medium_goedendag_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_medium_goedendag_handle_h3" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_goedendag_v2_h0" name="{=}Light Goedendag" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_light_goedendag_v3_h0" name="{=}Light Goedendag" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_goedendag_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_light_goedendag_handle_h0" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_goedendag_v2_h1" name="{=}Light Goedendag +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_light_goedendag_v3_h1" name="{=}Light Goedendag +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_goedendag_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_light_goedendag_handle_h1" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_goedendag_v2_h2" name="{=}Light Goedendag +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_light_goedendag_v3_h2" name="{=}Light Goedendag +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_goedendag_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_light_goedendag_handle_h2" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_goedendag_v2_h3" name="{=}Light Goedendag +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_light_goedendag_v3_h3" name="{=}Light Goedendag +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_goedendag_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_light_goedendag_handle_h3" Type="Handle" scale_factor="110" />
@@ -600,25 +600,25 @@
       <Piece id="crpg_shepherd_axe_handle_h3" Type="Handle" scale_factor="155" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_kama_v4_h0" name="{=}Kama" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_kama_v5_h0" name="{=}Kama" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_kama_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_kama_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_kama_v4_h1" name="{=}Kama +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_kama_v5_h1" name="{=}Kama +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_kama_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_kama_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_kama_v4_h2" name="{=}Kama +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_kama_v5_h2" name="{=}Kama +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_kama_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_kama_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_kama_v4_h3" name="{=}Kama +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_kama_v5_h3" name="{=}Kama +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_kama_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_kama_handle_h3" Type="Handle" scale_factor="100" />
@@ -4220,108 +4220,108 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <CraftedItem id="crpg_steel_flanged_mace_v2_h0" name="{=fz23ajFz}Steel Flanged Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steel_flanged_mace_v3_h0" name="{=fz23ajFz}Steel Flanged Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_flanged_mace_blade_h0" Type="Blade" />
       <Piece id="crpg_steel_flanged_mace_handle_h0" Type="Handle" scale_factor="88" />
       <Piece id="crpg_steel_flanged_mace_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_flanged_mace_v2_h1" name="{=fz23ajFz}Steel Flanged Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steel_flanged_mace_v3_h1" name="{=fz23ajFz}Steel Flanged Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_flanged_mace_blade_h1" Type="Blade" />
       <Piece id="crpg_steel_flanged_mace_handle_h1" Type="Handle" scale_factor="88" />
       <Piece id="crpg_steel_flanged_mace_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_flanged_mace_v2_h2" name="{=fz23ajFz}Steel Flanged Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steel_flanged_mace_v3_h2" name="{=fz23ajFz}Steel Flanged Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_flanged_mace_blade_h2" Type="Blade" />
       <Piece id="crpg_steel_flanged_mace_handle_h2" Type="Handle" scale_factor="88" />
       <Piece id="crpg_steel_flanged_mace_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_flanged_mace_v2_h3" name="{=fz23ajFz}Steel Flanged Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steel_flanged_mace_v3_h3" name="{=fz23ajFz}Steel Flanged Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_flanged_mace_blade_h3" Type="Blade" />
       <Piece id="crpg_steel_flanged_mace_handle_h3" Type="Handle" scale_factor="88" />
       <Piece id="crpg_steel_flanged_mace_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_mace_v2_h0" name="{=Kv4zAMIh}Cataphract Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_cataphract_mace_v3_h0" name="{=Kv4zAMIh}Cataphract Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_cataphract_mace_blade_h0" Type="Blade" scale_factor="140" />
       <Piece id="crpg_cataphract_mace_handle_h0" Type="Handle" scale_factor="130" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_mace_v2_h1" name="{=Kv4zAMIh}Cataphract Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_cataphract_mace_v3_h1" name="{=Kv4zAMIh}Cataphract Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_cataphract_mace_blade_h1" Type="Blade" scale_factor="140" />
       <Piece id="crpg_cataphract_mace_handle_h1" Type="Handle" scale_factor="130" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_mace_v2_h2" name="{=Kv4zAMIh}Cataphract Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_cataphract_mace_v3_h2" name="{=Kv4zAMIh}Cataphract Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_cataphract_mace_blade_h2" Type="Blade" scale_factor="140" />
       <Piece id="crpg_cataphract_mace_handle_h2" Type="Handle" scale_factor="130" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_mace_v2_h3" name="{=Kv4zAMIh}Cataphract Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_cataphract_mace_v3_h3" name="{=Kv4zAMIh}Cataphract Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_cataphract_mace_blade_h3" Type="Blade" scale_factor="140" />
       <Piece id="crpg_cataphract_mace_handle_h3" Type="Handle" scale_factor="130" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_royal_mace_v2_h0" name="{=UMX05EQF}Light Royal Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_light_royal_mace_v3_h0" name="{=UMX05EQF}Light Royal Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_royal_mace_blade_h0" Type="Blade" scale_factor="105" />
       <Piece id="crpg_light_royal_mace_handle_h0" Type="Handle" scale_factor="115" />
       <Piece id="crpg_light_royal_mace_pommel_h0" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_royal_mace_v2_h1" name="{=UMX05EQF}Light Royal Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_light_royal_mace_v3_h1" name="{=UMX05EQF}Light Royal Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_royal_mace_blade_h1" Type="Blade" scale_factor="105" />
       <Piece id="crpg_light_royal_mace_handle_h1" Type="Handle" scale_factor="115" />
       <Piece id="crpg_light_royal_mace_pommel_h1" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_royal_mace_v2_h2" name="{=UMX05EQF}Light Royal Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_light_royal_mace_v3_h2" name="{=UMX05EQF}Light Royal Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_royal_mace_blade_h2" Type="Blade" scale_factor="105" />
       <Piece id="crpg_light_royal_mace_handle_h2" Type="Handle" scale_factor="115" />
       <Piece id="crpg_light_royal_mace_pommel_h2" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_royal_mace_v2_h3" name="{=UMX05EQF}Light Royal Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_light_royal_mace_v3_h3" name="{=UMX05EQF}Light Royal Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_royal_mace_blade_h3" Type="Blade" scale_factor="105" />
       <Piece id="crpg_light_royal_mace_handle_h3" Type="Handle" scale_factor="115" />
       <Piece id="crpg_light_royal_mace_pommel_h3" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pernach_v2_h0" name="{=rnzpyc0N}Steel Pernach" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pernach_v3_h0" name="{=rnzpyc0N}Steel Pernach" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pernach_blade_h0" Type="Blade" scale_factor="150" />
       <Piece id="crpg_steel_pernach_handle_h0" Type="Handle" scale_factor="117" />
       <Piece id="crpg_steel_pernach_pommel_h0" Type="Pommel" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pernach_v2_h1" name="{=rnzpyc0N}Steel Pernach +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pernach_v3_h1" name="{=rnzpyc0N}Steel Pernach +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pernach_blade_h1" Type="Blade" scale_factor="150" />
       <Piece id="crpg_steel_pernach_handle_h1" Type="Handle" scale_factor="117" />
       <Piece id="crpg_steel_pernach_pommel_h1" Type="Pommel" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pernach_v2_h2" name="{=rnzpyc0N}Steel Pernach +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pernach_v3_h2" name="{=rnzpyc0N}Steel Pernach +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pernach_blade_h2" Type="Blade" scale_factor="150" />
       <Piece id="crpg_steel_pernach_handle_h2" Type="Handle" scale_factor="117" />
       <Piece id="crpg_steel_pernach_pommel_h2" Type="Pommel" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pernach_v2_h3" name="{=rnzpyc0N}Steel Pernach +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pernach_v3_h3" name="{=rnzpyc0N}Steel Pernach +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pernach_blade_h3" Type="Blade" scale_factor="150" />
       <Piece id="crpg_steel_pernach_handle_h3" Type="Handle" scale_factor="117" />
@@ -4356,212 +4356,212 @@
       <Piece id="crpg_long_steel_mace_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_crusher_v2_h0" name="{=xYk4953c}Bone Crusher" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_bone_crusher_v3_h0" name="{=xYk4953c}Bone Crusher" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bone_crusher_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bone_crusher_handle_h0" Type="Handle" scale_factor="118" />
       <Piece id="crpg_bone_crusher_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_crusher_v2_h1" name="{=xYk4953c}Bone Crusher +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_bone_crusher_v3_h1" name="{=xYk4953c}Bone Crusher +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bone_crusher_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bone_crusher_handle_h1" Type="Handle" scale_factor="118" />
       <Piece id="crpg_bone_crusher_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_crusher_v2_h2" name="{=xYk4953c}Bone Crusher +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_bone_crusher_v3_h2" name="{=xYk4953c}Bone Crusher +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bone_crusher_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bone_crusher_handle_h2" Type="Handle" scale_factor="118" />
       <Piece id="crpg_bone_crusher_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_crusher_v2_h3" name="{=xYk4953c}Bone Crusher +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_bone_crusher_v3_h3" name="{=xYk4953c}Bone Crusher +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bone_crusher_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bone_crusher_handle_h3" Type="Handle" scale_factor="118" />
       <Piece id="crpg_bone_crusher_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v2_h0" name="{=9EWN9SiT}Decorated Round Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v3_h0" name="{=9EWN9SiT}Decorated Round Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h0" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v2_h1" name="{=9EWN9SiT}Decorated Round Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v3_h1" name="{=9EWN9SiT}Decorated Round Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h1" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v2_h2" name="{=9EWN9SiT}Decorated Round Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v3_h2" name="{=9EWN9SiT}Decorated Round Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h2" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v2_h3" name="{=9EWN9SiT}Decorated Round Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v3_h3" name="{=9EWN9SiT}Decorated Round Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h3" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_mace_v2_h0" name="{=b88lWWOo}Fine Steel Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_fine_steel_mace_v3_h0" name="{=b88lWWOo}Fine Steel Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fine_steel_mace_blade_h0" Type="Blade" scale_factor="170" />
       <Piece id="crpg_fine_steel_mace_handle_h0" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_mace_v2_h1" name="{=b88lWWOo}Fine Steel Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_fine_steel_mace_v3_h1" name="{=b88lWWOo}Fine Steel Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fine_steel_mace_blade_h1" Type="Blade" scale_factor="170" />
       <Piece id="crpg_fine_steel_mace_handle_h1" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_mace_v2_h2" name="{=b88lWWOo}Fine Steel Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_fine_steel_mace_v3_h2" name="{=b88lWWOo}Fine Steel Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fine_steel_mace_blade_h2" Type="Blade" scale_factor="170" />
       <Piece id="crpg_fine_steel_mace_handle_h2" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_mace_v2_h3" name="{=b88lWWOo}Fine Steel Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_fine_steel_mace_v3_h3" name="{=b88lWWOo}Fine Steel Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fine_steel_mace_blade_h3" Type="Blade" scale_factor="170" />
       <Piece id="crpg_fine_steel_mace_handle_h3" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_eastern_heavy_mace_v2_h0" name="{=fcgDtZy7}Eastern Heavy Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_eastern_heavy_mace_v3_h0" name="{=fcgDtZy7}Eastern Heavy Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_eastern_heavy_mace_blade_h0" Type="Blade" scale_factor="160" />
       <Piece id="crpg_eastern_heavy_mace_handle_h0" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_eastern_heavy_mace_v2_h1" name="{=fcgDtZy7}Eastern Heavy Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_eastern_heavy_mace_v3_h1" name="{=fcgDtZy7}Eastern Heavy Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_eastern_heavy_mace_blade_h1" Type="Blade" scale_factor="160" />
       <Piece id="crpg_eastern_heavy_mace_handle_h1" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_eastern_heavy_mace_v2_h2" name="{=fcgDtZy7}Eastern Heavy Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_eastern_heavy_mace_v3_h2" name="{=fcgDtZy7}Eastern Heavy Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_eastern_heavy_mace_blade_h2" Type="Blade" scale_factor="160" />
       <Piece id="crpg_eastern_heavy_mace_handle_h2" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_eastern_heavy_mace_v2_h3" name="{=fcgDtZy7}Eastern Heavy Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_eastern_heavy_mace_v3_h3" name="{=fcgDtZy7}Eastern Heavy Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_eastern_heavy_mace_blade_h3" Type="Blade" scale_factor="160" />
       <Piece id="crpg_eastern_heavy_mace_handle_h3" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiralled_mace_v2_h0" name="{=JM8Mjfa0}Spiralled Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_spiralled_mace_v3_h0" name="{=JM8Mjfa0}Spiralled Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiralled_mace_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_spiralled_mace_handle_h0" Type="Handle" scale_factor="130" />
       <Piece id="crpg_spiralled_mace_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiralled_mace_v2_h1" name="{=JM8Mjfa0}Spiralled Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_spiralled_mace_v3_h1" name="{=JM8Mjfa0}Spiralled Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiralled_mace_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_spiralled_mace_handle_h1" Type="Handle" scale_factor="130" />
       <Piece id="crpg_spiralled_mace_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiralled_mace_v2_h2" name="{=JM8Mjfa0}Spiralled Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_spiralled_mace_v3_h2" name="{=JM8Mjfa0}Spiralled Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiralled_mace_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_spiralled_mace_handle_h2" Type="Handle" scale_factor="130" />
       <Piece id="crpg_spiralled_mace_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiralled_mace_v2_h3" name="{=JM8Mjfa0}Spiralled Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_spiralled_mace_v3_h3" name="{=JM8Mjfa0}Spiralled Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiralled_mace_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_spiralled_mace_handle_h3" Type="Handle" scale_factor="130" />
       <Piece id="crpg_spiralled_mace_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_calradic_mace_v2_h0" name="{=YLplNGxb}Calradic Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_calradic_mace_v3_h0" name="{=YLplNGxb}Calradic Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_calradic_mace_blade_h0" Type="Blade" scale_factor="130" />
       <Piece id="crpg_calradic_mace_handle_h0" Type="Handle" scale_factor="150" />
       <Piece id="crpg_calradic_mace_pommel_h0" Type="Pommel" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_calradic_mace_v2_h1" name="{=YLplNGxb}Calradic Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_calradic_mace_v3_h1" name="{=YLplNGxb}Calradic Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_calradic_mace_blade_h1" Type="Blade" scale_factor="130" />
       <Piece id="crpg_calradic_mace_handle_h1" Type="Handle" scale_factor="150" />
       <Piece id="crpg_calradic_mace_pommel_h1" Type="Pommel" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_calradic_mace_v2_h2" name="{=YLplNGxb}Calradic Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_calradic_mace_v3_h2" name="{=YLplNGxb}Calradic Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_calradic_mace_blade_h2" Type="Blade" scale_factor="130" />
       <Piece id="crpg_calradic_mace_handle_h2" Type="Handle" scale_factor="150" />
       <Piece id="crpg_calradic_mace_pommel_h2" Type="Pommel" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_calradic_mace_v2_h3" name="{=YLplNGxb}Calradic Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_calradic_mace_v3_h3" name="{=YLplNGxb}Calradic Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_calradic_mace_blade_h3" Type="Blade" scale_factor="130" />
       <Piece id="crpg_calradic_mace_handle_h3" Type="Handle" scale_factor="150" />
       <Piece id="crpg_calradic_mace_pommel_h3" Type="Pommel" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shishpar_mace_v2_h0" name="{=4cMV1pY3}Light Shishpar Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_shishpar_mace_v3_h0" name="{=4cMV1pY3}Light Shishpar Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shishpar_mace_blade_h0" Type="Blade" scale_factor="95" />
       <Piece id="crpg_light_shishpar_mace_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shishpar_mace_v2_h1" name="{=4cMV1pY3}Light Shishpar Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_shishpar_mace_v3_h1" name="{=4cMV1pY3}Light Shishpar Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shishpar_mace_blade_h1" Type="Blade" scale_factor="95" />
       <Piece id="crpg_light_shishpar_mace_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shishpar_mace_v2_h2" name="{=4cMV1pY3}Light Shishpar Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_shishpar_mace_v3_h2" name="{=4cMV1pY3}Light Shishpar Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shishpar_mace_blade_h2" Type="Blade" scale_factor="95" />
       <Piece id="crpg_light_shishpar_mace_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shishpar_mace_v2_h3" name="{=4cMV1pY3}Light Shishpar Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_shishpar_mace_v3_h3" name="{=4cMV1pY3}Light Shishpar Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shishpar_mace_blade_h3" Type="Blade" scale_factor="95" />
       <Piece id="crpg_light_shishpar_mace_handle_h3" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fullered_western_mace_v2_h0" name="{=dSTxsYsh}Fullered Western Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_fullered_western_mace_v3_h0" name="{=dSTxsYsh}Fullered Western Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fullered_western_mace_blade_h0" Type="Blade" scale_factor="120" />
       <Piece id="crpg_fullered_western_mace_handle_h0" Type="Handle" scale_factor="158" />
       <Piece id="crpg_fullered_western_mace_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fullered_western_mace_v2_h1" name="{=dSTxsYsh}Fullered Western Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_fullered_western_mace_v3_h1" name="{=dSTxsYsh}Fullered Western Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fullered_western_mace_blade_h1" Type="Blade" scale_factor="120" />
       <Piece id="crpg_fullered_western_mace_handle_h1" Type="Handle" scale_factor="158" />
       <Piece id="crpg_fullered_western_mace_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fullered_western_mace_v2_h2" name="{=dSTxsYsh}Fullered Western Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_fullered_western_mace_v3_h2" name="{=dSTxsYsh}Fullered Western Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fullered_western_mace_blade_h2" Type="Blade" scale_factor="120" />
       <Piece id="crpg_fullered_western_mace_handle_h2" Type="Handle" scale_factor="158" />
       <Piece id="crpg_fullered_western_mace_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fullered_western_mace_v2_h3" name="{=dSTxsYsh}Fullered Western Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_fullered_western_mace_v3_h3" name="{=dSTxsYsh}Fullered Western Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fullered_western_mace_blade_h3" Type="Blade" scale_factor="120" />
       <Piece id="crpg_fullered_western_mace_handle_h3" Type="Handle" scale_factor="158" />
@@ -4596,133 +4596,133 @@
       <Piece id="crpg_heavy_morningstar_pommel_h3" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_morningstar_v2_h0" name="{=6EWm09LY}Morningstar" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_morningstar_v3_h0" name="{=6EWm09LY}Morningstar" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_morningstar_blade_h0" Type="Blade" scale_factor="135" />
       <Piece id="crpg_morningstar_handle_h0" Type="Handle" scale_factor="115" />
       <Piece id="crpg_morningstar_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_morningstar_v2_h1" name="{=6EWm09LY}Morningstar +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_morningstar_v3_h1" name="{=6EWm09LY}Morningstar +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_morningstar_blade_h1" Type="Blade" scale_factor="135" />
       <Piece id="crpg_morningstar_handle_h1" Type="Handle" scale_factor="115" />
       <Piece id="crpg_morningstar_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_morningstar_v2_h2" name="{=6EWm09LY}Morningstar +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_morningstar_v3_h2" name="{=6EWm09LY}Morningstar +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_morningstar_blade_h2" Type="Blade" scale_factor="135" />
       <Piece id="crpg_morningstar_handle_h2" Type="Handle" scale_factor="115" />
       <Piece id="crpg_morningstar_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_morningstar_v2_h3" name="{=6EWm09LY}Morningstar +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_morningstar_v3_h3" name="{=6EWm09LY}Morningstar +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_morningstar_blade_h3" Type="Blade" scale_factor="135" />
       <Piece id="crpg_morningstar_handle_h3" Type="Handle" scale_factor="115" />
       <Piece id="crpg_morningstar_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_winged_shestopyor_v2_h0" name="{=8pnCvnFR}Steel Winged Shestopyor" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_steel_winged_shestopyor_v3_h0" name="{=8pnCvnFR}Steel Winged Shestopyor" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_winged_shestopyor_blade_h0" Type="Blade" scale_factor="145" />
       <Piece id="crpg_steel_winged_shestopyor_handle_h0" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_winged_shestopyor_v2_h1" name="{=8pnCvnFR}Steel Winged Shestopyor +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_steel_winged_shestopyor_v3_h1" name="{=8pnCvnFR}Steel Winged Shestopyor +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_winged_shestopyor_blade_h1" Type="Blade" scale_factor="145" />
       <Piece id="crpg_steel_winged_shestopyor_handle_h1" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_winged_shestopyor_v2_h2" name="{=8pnCvnFR}Steel Winged Shestopyor +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_steel_winged_shestopyor_v3_h2" name="{=8pnCvnFR}Steel Winged Shestopyor +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_winged_shestopyor_blade_h2" Type="Blade" scale_factor="145" />
       <Piece id="crpg_steel_winged_shestopyor_handle_h2" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_winged_shestopyor_v2_h3" name="{=8pnCvnFR}Steel Winged Shestopyor +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_steel_winged_shestopyor_v3_h3" name="{=8pnCvnFR}Steel Winged Shestopyor +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_winged_shestopyor_blade_h3" Type="Blade" scale_factor="145" />
       <Piece id="crpg_steel_winged_shestopyor_handle_h3" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_star_pointed_mace_v2_h0" name="{=PBLsXDgP}Star Pointed Mace" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_star_pointed_mace_v3_h0" name="{=PBLsXDgP}Star Pointed Mace" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_star_pointed_mace_blade_h0" Type="Blade" />
       <Piece id="crpg_star_pointed_mace_handle_h0" Type="Handle" scale_factor="89" />
       <Piece id="crpg_star_pointed_mace_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_star_pointed_mace_v2_h1" name="{=PBLsXDgP}Star Pointed Mace +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_star_pointed_mace_v3_h1" name="{=PBLsXDgP}Star Pointed Mace +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_star_pointed_mace_blade_h1" Type="Blade" />
       <Piece id="crpg_star_pointed_mace_handle_h1" Type="Handle" scale_factor="89" />
       <Piece id="crpg_star_pointed_mace_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_star_pointed_mace_v2_h2" name="{=PBLsXDgP}Star Pointed Mace +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_star_pointed_mace_v3_h2" name="{=PBLsXDgP}Star Pointed Mace +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_star_pointed_mace_blade_h2" Type="Blade" />
       <Piece id="crpg_star_pointed_mace_handle_h2" Type="Handle" scale_factor="89" />
       <Piece id="crpg_star_pointed_mace_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_star_pointed_mace_v2_h3" name="{=PBLsXDgP}Star Pointed Mace +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_star_pointed_mace_v3_h3" name="{=PBLsXDgP}Star Pointed Mace +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_star_pointed_mace_blade_h3" Type="Blade" />
       <Piece id="crpg_star_pointed_mace_handle_h3" Type="Handle" scale_factor="89" />
       <Piece id="crpg_star_pointed_mace_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_morningstar_v2_h0" name="{=9pD32UdV}Light Morningstar" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_light_morningstar_v3_h0" name="{=9pD32UdV}Light Morningstar" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_morningstar_blade_h0" Type="Blade" scale_factor="120" />
       <Piece id="crpg_light_morningstar_handle_h0" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_morningstar_pommel_h0" Type="Pommel" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_morningstar_v2_h1" name="{=9pD32UdV}Light Morningstar +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_light_morningstar_v3_h1" name="{=9pD32UdV}Light Morningstar +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_morningstar_blade_h1" Type="Blade" scale_factor="120" />
       <Piece id="crpg_light_morningstar_handle_h1" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_morningstar_pommel_h1" Type="Pommel" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_morningstar_v2_h2" name="{=9pD32UdV}Light Morningstar +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_light_morningstar_v3_h2" name="{=9pD32UdV}Light Morningstar +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_morningstar_blade_h2" Type="Blade" scale_factor="120" />
       <Piece id="crpg_light_morningstar_handle_h2" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_morningstar_pommel_h2" Type="Pommel" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_morningstar_v2_h3" name="{=9pD32UdV}Light Morningstar +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_light_morningstar_v3_h3" name="{=9pD32UdV}Light Morningstar +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_morningstar_blade_h3" Type="Blade" scale_factor="120" />
       <Piece id="crpg_light_morningstar_handle_h3" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_morningstar_pommel_h3" Type="Pommel" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_horsemans_mace_v2_h0" name="{=FJDCc3Y2}Heavy Horsemans Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_horsemans_mace_v3_h0" name="{=FJDCc3Y2}Heavy Horsemans Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_horsemans_mace_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_heavy_horsemans_mace_handle_h0" Type="Handle" scale_factor="170" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_horsemans_mace_v2_h1" name="{=FJDCc3Y2}Heavy Horsemans Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_horsemans_mace_v3_h1" name="{=FJDCc3Y2}Heavy Horsemans Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_horsemans_mace_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_heavy_horsemans_mace_handle_h1" Type="Handle" scale_factor="170" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_horsemans_mace_v2_h2" name="{=FJDCc3Y2}Heavy Horsemans Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_horsemans_mace_v3_h2" name="{=FJDCc3Y2}Heavy Horsemans Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_horsemans_mace_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_heavy_horsemans_mace_handle_h2" Type="Handle" scale_factor="170" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_horsemans_mace_v2_h3" name="{=FJDCc3Y2}Heavy Horsemans Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_horsemans_mace_v3_h3" name="{=FJDCc3Y2}Heavy Horsemans Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_horsemans_mace_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_heavy_horsemans_mace_handle_h3" Type="Handle" scale_factor="170" />
@@ -4752,129 +4752,129 @@
       <Piece id="crpg_highland_spiked_club_handle_h3" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_ball_club_v3_h0" name="{=knobbedclubweapon}Knobbed Ball Club" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_ball_club_v4_h0" name="{=knobbedclubweapon}Knobbed Ball Club" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_ball_club_blade_h0" Type="Blade" scale_factor="102" />
       <Piece id="crpg_knobbed_ball_club_handle_h0" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_ball_club_v3_h1" name="{=knobbedclubweapon}Knobbed Ball Club +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_ball_club_v4_h1" name="{=knobbedclubweapon}Knobbed Ball Club +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_ball_club_blade_h1" Type="Blade" scale_factor="102" />
       <Piece id="crpg_knobbed_ball_club_handle_h1" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_ball_club_v3_h2" name="{=knobbedclubweapon}Knobbed Ball Club +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_ball_club_v4_h2" name="{=knobbedclubweapon}Knobbed Ball Club +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_ball_club_blade_h2" Type="Blade" scale_factor="102" />
       <Piece id="crpg_knobbed_ball_club_handle_h2" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_ball_club_v3_h3" name="{=knobbedclubweapon}Knobbed Ball Club +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_ball_club_v4_h3" name="{=knobbedclubweapon}Knobbed Ball Club +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_ball_club_blade_h3" Type="Blade" scale_factor="102" />
       <Piece id="crpg_knobbed_ball_club_handle_h3" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steppe_spiked_mace_v2_h0" name="{=N8VJWdVY}Steppe Spiked Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steppe_spiked_mace_v3_h0" name="{=N8VJWdVY}Steppe Spiked Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steppe_spiked_mace_blade_h0" Type="Blade" />
       <Piece id="crpg_steppe_spiked_mace_handle_h0" Type="Handle" scale_factor="108" />
       <Piece id="crpg_steppe_spiked_mace_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steppe_spiked_mace_v2_h1" name="{=N8VJWdVY}Steppe Spiked Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steppe_spiked_mace_v3_h1" name="{=N8VJWdVY}Steppe Spiked Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steppe_spiked_mace_blade_h1" Type="Blade" />
       <Piece id="crpg_steppe_spiked_mace_handle_h1" Type="Handle" scale_factor="108" />
       <Piece id="crpg_steppe_spiked_mace_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steppe_spiked_mace_v2_h2" name="{=N8VJWdVY}Steppe Spiked Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steppe_spiked_mace_v3_h2" name="{=N8VJWdVY}Steppe Spiked Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steppe_spiked_mace_blade_h2" Type="Blade" />
       <Piece id="crpg_steppe_spiked_mace_handle_h2" Type="Handle" scale_factor="108" />
       <Piece id="crpg_steppe_spiked_mace_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steppe_spiked_mace_v2_h3" name="{=N8VJWdVY}Steppe Spiked Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steppe_spiked_mace_v3_h3" name="{=N8VJWdVY}Steppe Spiked Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steppe_spiked_mace_blade_h3" Type="Blade" />
       <Piece id="crpg_steppe_spiked_mace_handle_h3" Type="Handle" scale_factor="108" />
       <Piece id="crpg_steppe_spiked_mace_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v3_h0" name="{=6QI8X6CY}Winged Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v4_h0" name="{=6QI8X6CY}Winged Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_winged_mace_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h0" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v3_h1" name="{=6QI8X6CY}Winged Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v4_h1" name="{=6QI8X6CY}Winged Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_winged_mace_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h1" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v3_h2" name="{=6QI8X6CY}Winged Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v4_h2" name="{=6QI8X6CY}Winged Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_winged_mace_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h2" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v3_h3" name="{=6QI8X6CY}Winged Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v4_h3" name="{=6QI8X6CY}Winged Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_winged_mace_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h3" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rus_mace_v2_h0" name="{=wxL5TdDv}Rus Mace" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_rus_mace_v3_h0" name="{=wxL5TdDv}Rus Mace" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_rus_mace_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rus_mace_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_rus_mace_pommel_h0" Type="Pommel" scale_factor="92" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rus_mace_v2_h1" name="{=wxL5TdDv}Rus Mace +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_rus_mace_v3_h1" name="{=wxL5TdDv}Rus Mace +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_rus_mace_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rus_mace_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_rus_mace_pommel_h1" Type="Pommel" scale_factor="92" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rus_mace_v2_h2" name="{=wxL5TdDv}Rus Mace +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_rus_mace_v3_h2" name="{=wxL5TdDv}Rus Mace +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_rus_mace_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rus_mace_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_rus_mace_pommel_h2" Type="Pommel" scale_factor="92" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rus_mace_v2_h3" name="{=wxL5TdDv}Rus Mace +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_rus_mace_v3_h3" name="{=wxL5TdDv}Rus Mace +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_rus_mace_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rus_mace_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_rus_mace_pommel_h3" Type="Pommel" scale_factor="92" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_club_v2_h0" name="{=HaK3y9yi}Spiked Club" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_club_v3_h0" name="{=HaK3y9yi}Spiked Club" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_club_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_spiked_club_handle_h0" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_club_v2_h1" name="{=HaK3y9yi}Spiked Club +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_club_v3_h1" name="{=HaK3y9yi}Spiked Club +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_club_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_spiked_club_handle_h1" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_club_v2_h2" name="{=HaK3y9yi}Spiked Club +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_club_v3_h2" name="{=HaK3y9yi}Spiked Club +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_club_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_spiked_club_handle_h2" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_club_v2_h3" name="{=HaK3y9yi}Spiked Club +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_club_v3_h3" name="{=HaK3y9yi}Spiked Club +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_club_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_spiked_club_handle_h3" Type="Handle" scale_factor="120" />
@@ -10540,105 +10540,105 @@
       <Piece id="crpg_black_heart_axe_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_judgement_v2_h0" name="{=KRuZuMFI}Judgement" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_judgement_v3_h0" name="{=KRuZuMFI}Judgement" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_judgement_blade_h0" Type="Blade" scale_factor="155" />
       <Piece id="crpg_judgement_handle_h0" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_judgement_v2_h1" name="{=KRuZuMFI}Judgement +1" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_judgement_v3_h1" name="{=KRuZuMFI}Judgement +1" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_judgement_blade_h1" Type="Blade" scale_factor="155" />
       <Piece id="crpg_judgement_handle_h1" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_judgement_v2_h2" name="{=KRuZuMFI}Judgement +2" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_judgement_v3_h2" name="{=KRuZuMFI}Judgement +2" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_judgement_blade_h2" Type="Blade" scale_factor="155" />
       <Piece id="crpg_judgement_handle_h2" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_judgement_v2_h3" name="{=KRuZuMFI}Judgement +3" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_judgement_v3_h3" name="{=KRuZuMFI}Judgement +3" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_judgement_blade_h3" Type="Blade" scale_factor="155" />
       <Piece id="crpg_judgement_handle_h3" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knights_fall_v2_h0" name="{=BYPhysbH}Knight's Fall" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_knights_fall_v3_h0" name="{=BYPhysbH}Knight's Fall" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_knights_fall_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_knights_fall_handle_h0" Type="Handle" scale_factor="163" />
       <Piece id="crpg_knights_fall_pommel_h0" Type="Pommel" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knights_fall_v2_h1" name="{=BYPhysbH}Knight's Fall +1" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_knights_fall_v3_h1" name="{=BYPhysbH}Knight's Fall +1" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_knights_fall_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_knights_fall_handle_h1" Type="Handle" scale_factor="163" />
       <Piece id="crpg_knights_fall_pommel_h1" Type="Pommel" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knights_fall_v2_h2" name="{=BYPhysbH}Knight's Fall +2" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_knights_fall_v3_h2" name="{=BYPhysbH}Knight's Fall +2" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_knights_fall_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_knights_fall_handle_h2" Type="Handle" scale_factor="163" />
       <Piece id="crpg_knights_fall_pommel_h2" Type="Pommel" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knights_fall_v2_h3" name="{=BYPhysbH}Knight's Fall +3" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_knights_fall_v3_h3" name="{=BYPhysbH}Knight's Fall +3" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_knights_fall_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_knights_fall_handle_h3" Type="Handle" scale_factor="163" />
       <Piece id="crpg_knights_fall_pommel_h3" Type="Pommel" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_militia_pernach_v2_h0" name="{=WASZXuec}Militia Pernach" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_militia_pernach_v1_h0" name="{=WASZXuec}Militia Pernach" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_militia_pernach_blade_h0" Type="Blade" scale_factor="137" />
       <Piece id="crpg_militia_pernach_handle_h0" Type="Handle" scale_factor="142" />
       <Piece id="crpg_militia_pernach_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_militia_pernach_v2_h1" name="{=WASZXuec}Militia Pernach +1" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_militia_pernach_v1_h1" name="{=WASZXuec}Militia Pernach +1" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_militia_pernach_blade_h1" Type="Blade" scale_factor="137" />
       <Piece id="crpg_militia_pernach_handle_h1" Type="Handle" scale_factor="142" />
       <Piece id="crpg_militia_pernach_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_militia_pernach_v2_h2" name="{=WASZXuec}Militia Pernach +2" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_militia_pernach_v1_h2" name="{=WASZXuec}Militia Pernach +2" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_militia_pernach_blade_h2" Type="Blade" scale_factor="137" />
       <Piece id="crpg_militia_pernach_handle_h2" Type="Handle" scale_factor="142" />
       <Piece id="crpg_militia_pernach_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_militia_pernach_v2_h3" name="{=WASZXuec}Militia Pernach +3" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_militia_pernach_v1_h3" name="{=WASZXuec}Militia Pernach +3" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_militia_pernach_blade_h3" Type="Blade" scale_factor="137" />
       <Piece id="crpg_militia_pernach_handle_h3" Type="Handle" scale_factor="142" />
       <Piece id="crpg_militia_pernach_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_flanged_mace_v2_h0" name="{=mzvtFPPi}Heavy Flanged Mace" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_heavy_flanged_mace_v3_h0" name="{=mzvtFPPi}Heavy Flanged Mace" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_heavy_flanged_mace_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_flanged_mace_handle_h0" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_flanged_mace_v2_h1" name="{=mzvtFPPi}Heavy Flanged Mace +1" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_heavy_flanged_mace_v3_h1" name="{=mzvtFPPi}Heavy Flanged Mace +1" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_heavy_flanged_mace_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_flanged_mace_handle_h1" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_flanged_mace_v2_h2" name="{=mzvtFPPi}Heavy Flanged Mace +2" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_heavy_flanged_mace_v3_h2" name="{=mzvtFPPi}Heavy Flanged Mace +2" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_heavy_flanged_mace_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_flanged_mace_handle_h2" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_flanged_mace_v2_h3" name="{=mzvtFPPi}Heavy Flanged Mace +3" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_heavy_flanged_mace_v3_h3" name="{=mzvtFPPi}Heavy Flanged Mace +3" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_heavy_flanged_mace_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_flanged_mace_handle_h3" Type="Handle" scale_factor="95" />
@@ -11248,49 +11248,49 @@
       <Piece id="crpg_wooden_hammer_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_warhammer_v2_h0" name="{=6WcZ5Tr0}Blacksmith Warhammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_warhammer_v3_h0" name="{=6WcZ5Tr0}Blacksmith Warhammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_warhammer_blade_h0" Type="Blade" scale_factor="140" />
       <Piece id="crpg_blacksmith_warhammer_handle_h0" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_warhammer_v2_h1" name="{=6WcZ5Tr0}Blacksmith Warhammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_warhammer_v3_h1" name="{=6WcZ5Tr0}Blacksmith Warhammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_warhammer_blade_h1" Type="Blade" scale_factor="140" />
       <Piece id="crpg_blacksmith_warhammer_handle_h1" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_warhammer_v2_h2" name="{=6WcZ5Tr0}Blacksmith Warhammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_warhammer_v3_h2" name="{=6WcZ5Tr0}Blacksmith Warhammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_warhammer_blade_h2" Type="Blade" scale_factor="140" />
       <Piece id="crpg_blacksmith_warhammer_handle_h2" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_warhammer_v2_h3" name="{=6WcZ5Tr0}Blacksmith Warhammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_warhammer_v3_h3" name="{=6WcZ5Tr0}Blacksmith Warhammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_warhammer_blade_h3" Type="Blade" scale_factor="140" />
       <Piece id="crpg_blacksmith_warhammer_handle_h3" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v3_h0" name="{=6WcZ5Tr0}Blacksmith Hammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v4_h0" name="{=6WcZ5Tr0}Blacksmith Hammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_hammer_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_blacksmith_hammer_handle_h0" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v3_h1" name="{=6WcZ5Tr0}Blacksmith Hammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v4_h1" name="{=6WcZ5Tr0}Blacksmith Hammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_hammer_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_blacksmith_hammer_handle_h1" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v3_h2" name="{=6WcZ5Tr0}Blacksmith Hammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v4_h2" name="{=6WcZ5Tr0}Blacksmith Hammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_hammer_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_blacksmith_hammer_handle_h2" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v3_h3" name="{=6WcZ5Tr0}Blacksmith Hammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v4_h3" name="{=6WcZ5Tr0}Blacksmith Hammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_hammer_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_blacksmith_hammer_handle_h3" Type="Handle" scale_factor="125" />
@@ -11512,25 +11512,25 @@
       <Piece id="crpg_spiral_shuriken_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pick_v4_h0" name="Steel Pick" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pick_v5_h0" name="Steel Pick" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pick_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_steel_pick_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pick_v4_h1" name="Steel Pick +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pick_v5_h1" name="Steel Pick +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pick_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_steel_pick_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pick_v4_h2" name="Steel Pick +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pick_v5_h2" name="Steel Pick +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pick_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_steel_pick_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pick_v4_h3" name="Steel Pick +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pick_v5_h3" name="Steel Pick +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pick_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_steel_pick_handle_h3" Type="Handle" scale_factor="100" />
@@ -11824,257 +11824,257 @@
       <Piece id="crpg_rondel_pommel_h3" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_cavalry_mace_v2_h0" name="{=Telford}Long Cavalry Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_cavalry_mace_v3_h0" name="{=Telford}Long Cavalry Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_cavalry_mace_blade_h0" Type="Blade" scale_factor="120" />
       <Piece id="crpg_long_cavalry_mace_handle_h0" Type="Handle" scale_factor="152" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_cavalry_mace_v2_h1" name="{=Telford}Long Cavalry Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_cavalry_mace_v3_h1" name="{=Telford}Long Cavalry Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_cavalry_mace_blade_h1" Type="Blade" scale_factor="120" />
       <Piece id="crpg_long_cavalry_mace_handle_h1" Type="Handle" scale_factor="152" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_cavalry_mace_v2_h2" name="{=Telford}Long Cavalry Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_cavalry_mace_v3_h2" name="{=Telford}Long Cavalry Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_cavalry_mace_blade_h2" Type="Blade" scale_factor="120" />
       <Piece id="crpg_long_cavalry_mace_handle_h2" Type="Handle" scale_factor="152" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_cavalry_mace_v2_h3" name="{=Telford}Long Cavalry Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_cavalry_mace_v3_h3" name="{=Telford}Long Cavalry Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_cavalry_mace_blade_h3" Type="Blade" scale_factor="120" />
       <Piece id="crpg_long_cavalry_mace_handle_h3" Type="Handle" scale_factor="152" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_pernach_v2_h0" name="{=Telford}Long Pernach" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_long_pernach_v3_h0" name="{=Telford}Long Pernach" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_pernach_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_long_pernach_handle_h0" Type="Handle" scale_factor="119" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_pernach_v2_h1" name="{=Telford}Long Pernach +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_long_pernach_v3_h1" name="{=Telford}Long Pernach +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_pernach_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_long_pernach_handle_h1" Type="Handle" scale_factor="119" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_pernach_v2_h2" name="{=Telford}Long Pernach +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_long_pernach_v3_h2" name="{=Telford}Long Pernach +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_pernach_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_long_pernach_handle_h2" Type="Handle" scale_factor="119" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_pernach_v2_h3" name="{=Telford}Long Pernach +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_long_pernach_v3_h3" name="{=Telford}Long Pernach +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_pernach_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_long_pernach_handle_h3" Type="Handle" scale_factor="119" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_persian_steel_mace_v2_h0" name="{=Telford}Persian Steel Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_persian_steel_mace_v3_h0" name="{=Telford}Persian Steel Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_persian_steel_mace_blade_h0" Type="Blade" scale_factor="78" />
       <Piece id="crpg_persian_steel_mace_handle_h0" Type="Handle" scale_factor="116" />
       <Piece id="crpg_persian_steel_mace_pommel_h0" Type="Pommel" scale_factor="59" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_persian_steel_mace_v2_h1" name="{=Telford}Persian Steel Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_persian_steel_mace_v3_h1" name="{=Telford}Persian Steel Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_persian_steel_mace_blade_h1" Type="Blade" scale_factor="78" />
       <Piece id="crpg_persian_steel_mace_handle_h1" Type="Handle" scale_factor="116" />
       <Piece id="crpg_persian_steel_mace_pommel_h1" Type="Pommel" scale_factor="59" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_persian_steel_mace_v2_h2" name="{=Telford}Persian Steel Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_persian_steel_mace_v3_h2" name="{=Telford}Persian Steel Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_persian_steel_mace_blade_h2" Type="Blade" scale_factor="78" />
       <Piece id="crpg_persian_steel_mace_handle_h2" Type="Handle" scale_factor="116" />
       <Piece id="crpg_persian_steel_mace_pommel_h2" Type="Pommel" scale_factor="59" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_persian_steel_mace_v2_h3" name="{=Telford}Persian Steel Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_persian_steel_mace_v3_h3" name="{=Telford}Persian Steel Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_persian_steel_mace_blade_h3" Type="Blade" scale_factor="78" />
       <Piece id="crpg_persian_steel_mace_handle_h3" Type="Handle" scale_factor="116" />
       <Piece id="crpg_persian_steel_mace_pommel_h3" Type="Pommel" scale_factor="59" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_mace_v2_h0" name="{=JM8Mjfa0}Flanged Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_mace_v3_h0" name="{=JM8Mjfa0}Flanged Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_mace_blade_h0" Type="Blade" scale_factor="75" />
       <Piece id="crpg_flanged_mace_handle_h0" Type="Handle" scale_factor="110" />
       <Piece id="crpg_flanged_mace_pommel_h0" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_mace_v2_h1" name="{=JM8Mjfa0}Flanged Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_mace_v3_h1" name="{=JM8Mjfa0}Flanged Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_mace_blade_h1" Type="Blade" scale_factor="75" />
       <Piece id="crpg_flanged_mace_handle_h1" Type="Handle" scale_factor="110" />
       <Piece id="crpg_flanged_mace_pommel_h1" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_mace_v2_h2" name="{=JM8Mjfa0}Flanged Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_mace_v3_h2" name="{=JM8Mjfa0}Flanged Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_mace_blade_h2" Type="Blade" scale_factor="75" />
       <Piece id="crpg_flanged_mace_handle_h2" Type="Handle" scale_factor="110" />
       <Piece id="crpg_flanged_mace_pommel_h2" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_mace_v2_h3" name="{=JM8Mjfa0}Flanged Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_mace_v3_h3" name="{=JM8Mjfa0}Flanged Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_mace_blade_h3" Type="Blade" scale_factor="75" />
       <Piece id="crpg_flanged_mace_handle_h3" Type="Handle" scale_factor="110" />
       <Piece id="crpg_flanged_mace_pommel_h3" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_arabian_mace_v2_h0" name="{=fz23ajFz}Arabian Mace" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_arabian_mace_v3_h0" name="{=fz23ajFz}Arabian Mace" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_arabian_mace_blade_h0" Type="Blade" scale_factor="130" />
       <Piece id="crpg_arabian_mace_handle_h0" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_arabian_mace_v2_h1" name="{=fz23ajFz}Arabian Mace +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_arabian_mace_v3_h1" name="{=fz23ajFz}Arabian Mace +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_arabian_mace_blade_h1" Type="Blade" scale_factor="130" />
       <Piece id="crpg_arabian_mace_handle_h1" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_arabian_mace_v2_h2" name="{=fz23ajFz}Arabian Mace +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_arabian_mace_v3_h2" name="{=fz23ajFz}Arabian Mace +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_arabian_mace_blade_h2" Type="Blade" scale_factor="130" />
       <Piece id="crpg_arabian_mace_handle_h2" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_arabian_mace_v2_h3" name="{=fz23ajFz}Arabian Mace +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_arabian_mace_v3_h3" name="{=fz23ajFz}Arabian Mace +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_arabian_mace_blade_h3" Type="Blade" scale_factor="130" />
       <Piece id="crpg_arabian_mace_handle_h3" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_ball_mace_v2_h0" name="{=JM8Mjfa0}Flanged Ball Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_ball_mace_v3_h0" name="{=JM8Mjfa0}Flanged Ball Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_ball_mace_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_flanged_ball_mace_handle_h0" Type="Handle" scale_factor="109" />
       <Piece id="crpg_flanged_ball_mace_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_ball_mace_v2_h1" name="{=JM8Mjfa0}Flanged Ball Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_ball_mace_v3_h1" name="{=JM8Mjfa0}Flanged Ball Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_ball_mace_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_flanged_ball_mace_handle_h1" Type="Handle" scale_factor="109" />
       <Piece id="crpg_flanged_ball_mace_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_ball_mace_v2_h2" name="{=JM8Mjfa0}Flanged Ball Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_ball_mace_v3_h2" name="{=JM8Mjfa0}Flanged Ball Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_ball_mace_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_flanged_ball_mace_handle_h2" Type="Handle" scale_factor="109" />
       <Piece id="crpg_flanged_ball_mace_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_ball_mace_v2_h3" name="{=JM8Mjfa0}Flanged Ball Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_ball_mace_v3_h3" name="{=JM8Mjfa0}Flanged Ball Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_ball_mace_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_flanged_ball_mace_handle_h3" Type="Handle" scale_factor="109" />
       <Piece id="crpg_flanged_ball_mace_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_byzantine_mace_v2_h0" name="{=Telford}Byzantine Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_byzantine_mace_v3_h0" name="{=Telford}Byzantine Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_byzantine_mace_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_byzantine_mace_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_byzantine_mace_v2_h1" name="{=Telford}Byzantine Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_byzantine_mace_v3_h1" name="{=Telford}Byzantine Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_byzantine_mace_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_byzantine_mace_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_byzantine_mace_v2_h2" name="{=Telford}Byzantine Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_byzantine_mace_v3_h2" name="{=Telford}Byzantine Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_byzantine_mace_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_byzantine_mace_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_byzantine_mace_v2_h3" name="{=Telford}Byzantine Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_byzantine_mace_v3_h3" name="{=Telford}Byzantine Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_byzantine_mace_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_byzantine_mace_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shestopyor_v3_h0" name="{=8pnCvnFR}Light Shestopyor" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_light_shestopyor_v4_h0" name="{=8pnCvnFR}Light Shestopyor" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shestopyor_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_light_shestopyor_handle_h0" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_shestopyor_pommel_h0" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shestopyor_v3_h1" name="{=8pnCvnFR}Light Shestopyor +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_light_shestopyor_v4_h1" name="{=8pnCvnFR}Light Shestopyor +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shestopyor_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_light_shestopyor_handle_h1" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_shestopyor_pommel_h1" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shestopyor_v3_h2" name="{=8pnCvnFR}Light Shestopyor +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_light_shestopyor_v4_h2" name="{=8pnCvnFR}Light Shestopyor +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shestopyor_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_light_shestopyor_handle_h2" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_shestopyor_pommel_h2" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shestopyor_v3_h3" name="{=8pnCvnFR}Light Shestopyor +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_light_shestopyor_v4_h3" name="{=8pnCvnFR}Light Shestopyor +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shestopyor_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_light_shestopyor_handle_h3" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_shestopyor_pommel_h3" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_mace_v2_h0" name="{=Telford}Knobbed Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_mace_v3_h0" name="{=Telford}Knobbed Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_mace_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knobbed_mace_handle_h0" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_mace_v2_h1" name="{=Telford}Knobbed Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_mace_v3_h1" name="{=Telford}Knobbed Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_mace_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knobbed_mace_handle_h1" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_mace_v2_h2" name="{=Telford}Knobbed Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_mace_v3_h2" name="{=Telford}Knobbed Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_mace_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knobbed_mace_handle_h2" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_mace_v2_h3" name="{=Telford}Knobbed Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_mace_v3_h3" name="{=Telford}Knobbed Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_mace_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knobbed_mace_handle_h3" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v3_h0" name="{=dSTxsYsh}Short Western Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v4_h0" name="{=dSTxsYsh}Short Western Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h0" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h0" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v3_h1" name="{=dSTxsYsh}Short Western Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v4_h1" name="{=dSTxsYsh}Short Western Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h1" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h1" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v3_h2" name="{=dSTxsYsh}Short Western Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v4_h2" name="{=dSTxsYsh}Short Western Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h2" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h2" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v3_h3" name="{=dSTxsYsh}Short Western Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v4_h3" name="{=dSTxsYsh}Short Western Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h3" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h3" Type="Handle" scale_factor="105" />
@@ -12584,28 +12584,28 @@
       <Piece id="crpg_rondel_reverse_pommel_h3" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemanspick_v2_h0" name="{=}Horseman's Pick" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_horsemanspick_v3_h0" name="{=}Horseman's Pick" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_horsemanspick_head_h0" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_horsemanspick_handle_h0" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_horsemanspick_handle_h0" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemanspick_v2_h1" name="{=}Horseman's Pick +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_horsemanspick_v3_h1" name="{=}Horseman's Pick +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_horsemanspick_head_h1" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_horsemanspick_handle_h1" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_horsemanspick_handle_h1" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemanspick_v2_h2" name="{=}Horseman's Pick +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_horsemanspick_v3_h2" name="{=}Horseman's Pick +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_horsemanspick_head_h2" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_horsemanspick_handle_h2" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_horsemanspick_handle_h2" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemanspick_v2_h3" name="{=}Horseman's Pick +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_horsemanspick_v3_h3" name="{=}Horseman's Pick +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_horsemanspick_head_h3" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_horsemanspick_handle_h3" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_horsemanspick_handle_h3" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_shep_damast_v3_h0" name="Elegant Shepherd Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
@@ -12756,49 +12756,49 @@
       <Piece id="crpg_zweihander_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_gada_v2_h0" name="{=}Steel Ball Mace" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_gada_v3_h0" name="{=}Steel Ball Mace" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_gada_blade_h0" Type="Blade" scale_factor="60" />
       <Piece id="crpg_onehanded_gada_handle_h0" Type="Handle" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_gada_v2_h1" name="{=}Steel Ball Mace +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_gada_v3_h1" name="{=}Steel Ball Mace +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_gada_blade_h1" Type="Blade" scale_factor="60" />
       <Piece id="crpg_onehanded_gada_handle_h1" Type="Handle" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_gada_v2_h2" name="{=}Steel Ball Mace +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_gada_v3_h2" name="{=}Steel Ball Mace +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_gada_blade_h2" Type="Blade" scale_factor="60" />
       <Piece id="crpg_onehanded_gada_handle_h2" Type="Handle" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_gada_v2_h3" name="{=}Steel Ball Mace +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_gada_v3_h3" name="{=}Steel Ball Mace +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_gada_blade_h3" Type="Blade" scale_factor="60" />
       <Piece id="crpg_onehanded_gada_handle_h3" Type="Handle" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_barmace_v2_h0" name="{=}One-Handed Barmace" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_barmace_v3_h0" name="{=}One-Handed Barmace" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_barmace_blade_h0" Type="Blade" scale_factor="95" />
       <Piece id="crpg_onehanded_barmace_handle_h0" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_barmace_v2_h1" name="{=}One-Handed Barmace +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_barmace_v3_h1" name="{=}One-Handed Barmace +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_barmace_blade_h1" Type="Blade" scale_factor="95" />
       <Piece id="crpg_onehanded_barmace_handle_h1" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_barmace_v2_h2" name="{=}One-Handed Barmace +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_barmace_v3_h2" name="{=}One-Handed Barmace +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_barmace_blade_h2" Type="Blade" scale_factor="95" />
       <Piece id="crpg_onehanded_barmace_handle_h2" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_barmace_v2_h3" name="{=}One-Handed Barmace +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_barmace_v3_h3" name="{=}One-Handed Barmace +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_barmace_blade_h3" Type="Blade" scale_factor="95" />
       <Piece id="crpg_onehanded_barmace_handle_h3" Type="Handle" scale_factor="95" />
@@ -14052,25 +14052,25 @@
       <Piece id="crpg_fabulousvoulge_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_smallhammer_v1_h0" name="{=}Elder's Hammer" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_smallhammer_v2_h0" name="{=}Elder's Hammer" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_smallhammer_blade_h0" Type="Blade" scale_factor="140" />
       <Piece id="crpg_smallhammer_handle_h0" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_smallhammer_v1_h1" name="{=}Elder's Hammer +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_smallhammer_v2_h1" name="{=}Elder's Hammer +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_smallhammer_blade_h1" Type="Blade" scale_factor="140" />
       <Piece id="crpg_smallhammer_handle_h1" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_smallhammer_v1_h2" name="{=}Elder's Hammer +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_smallhammer_v2_h2" name="{=}Elder's Hammer +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_smallhammer_blade_h2" Type="Blade" scale_factor="140" />
       <Piece id="crpg_smallhammer_handle_h2" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_smallhammer_v1_h3" name="{=}Elder's Hammer +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_smallhammer_v2_h3" name="{=}Elder's Hammer +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_smallhammer_blade_h3" Type="Blade" scale_factor="140" />
       <Piece id="crpg_smallhammer_handle_h3" Type="Handle" scale_factor="140" />
@@ -14788,28 +14788,28 @@
       <Piece id="crpg_katzbalger_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bobs_ballmace_h0" name="{=Salt}Spiked Ballmace" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_bobs_ballmace_v1_h0" name="{=Salt}Spiked Ballmace" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bobs_ballmace_head_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_bobs_ballmace_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_bobs_ballmace_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bobs_ballmace_h1" name="{=Salt}Spiked Ballmace +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_bobs_ballmace_v1_h1" name="{=Salt}Spiked Ballmace +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bobs_ballmace_head_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_bobs_ballmace_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_bobs_ballmace_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bobs_ballmace_h2" name="{=Salt}Spiked Ballmace +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_bobs_ballmace_v1_h2" name="{=Salt}Spiked Ballmace +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bobs_ballmace_head_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_bobs_ballmace_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_bobs_ballmace_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bobs_ballmace_h3" name="{=Salt}Spiked Ballmace +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_bobs_ballmace_v1_h3" name="{=Salt}Spiked Ballmace +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bobs_ballmace_head_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_bobs_ballmace_handle_h3" Type="Handle" scale_factor="100" />

--- a/weapon_descriptions.xml
+++ b/weapon_descriptions.xml
@@ -9449,14 +9449,6 @@
       <AvailablePiece id="crpg_spiked_polehammer_handle_h1" />
       <AvailablePiece id="crpg_spiked_polehammer_handle_h2" />
       <AvailablePiece id="crpg_spiked_polehammer_handle_h3" />
-      <AvailablePiece id="crpg_spiked_polehammer_knockdown_blade_h0" />
-      <AvailablePiece id="crpg_spiked_polehammer_knockdown_blade_h1" />
-      <AvailablePiece id="crpg_spiked_polehammer_knockdown_blade_h2" />
-      <AvailablePiece id="crpg_spiked_polehammer_knockdown_blade_h3" />
-      <AvailablePiece id="crpg_spiked_polehammer_knockdown_handle_h0" />
-      <AvailablePiece id="crpg_spiked_polehammer_knockdown_handle_h1" />
-      <AvailablePiece id="crpg_spiked_polehammer_knockdown_handle_h2" />
-      <AvailablePiece id="crpg_spiked_polehammer_knockdown_handle_h3" />
       <AvailablePiece id="crpg_bec_de_corbin_handle_h0" />
       <AvailablePiece id="crpg_bec_de_corbin_handle_h1" />
       <AvailablePiece id="crpg_bec_de_corbin_handle_h2" />


### PR DESCRIPTION
Reducing the damage of the longest, most damaging polearms
Increasing the damage oh 1h maces

Includes balance-related changes:

- Remove polehammer knockdown mode
- Shorten Long Thamaskene Tipped Spear

See https://github.com/crpg2/crpg/pull/559