### PR TITLE
test two stage reload light xbow method

### DIFF
--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -14452,7 +14452,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_disabled_wheellock_v1_h0" name="{=AppleTruce}Wheellock test" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_disabled_wheellock_v1_h0" name="{=AppleTruce}Wheellock test" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="108" accuracy="97" thrust_damage="44" thrust_speed="84" speed_rating="34" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
@@ -14460,7 +14460,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_disabled_wheellock_v1_h1" name="{=AppleTruce}Wheellock test +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_disabled_wheellock_v1_h1" name="{=AppleTruce}Wheellock test +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="108" accuracy="98" thrust_damage="45" thrust_speed="85" speed_rating="36" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
@@ -14468,7 +14468,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_disabled_wheellock_v1_h2" name="{=AppleTruce}Wheellock test +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_disabled_wheellock_v1_h2" name="{=AppleTruce}Wheellock test +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="109" accuracy="99" thrust_damage="46" thrust_speed="86" speed_rating="38" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
@@ -14476,7 +14476,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_disabled_wheellock_v1_h3" name="{=AppleTruce}Wheellock test +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+  <Item id="crpg_disabled_wheellock_v1_h3" name="{=AppleTruce}Wheellock test +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
       <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="110" accuracy="100" thrust_damage="47" thrust_speed="87" speed_rating="39" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -14420,41 +14420,9 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_disabled_handgonne_v1_h0" name="{=Meow}Handgonne test" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
-    <ItemComponent>
-      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="112" accuracy="95" thrust_damage="53" thrust_speed="80" speed_rating="28" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
-        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
-      </Weapon>
-    </ItemComponent>
-    <Flags />
-  </Item>
-  <Item id="crpg_disabled_handgonne_v1_h1" name="{=Meow}Handgonne test +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
-    <ItemComponent>
-      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="112" accuracy="96" thrust_damage="54" thrust_speed="81" speed_rating="30" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
-        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
-      </Weapon>
-    </ItemComponent>
-    <Flags />
-  </Item>
-  <Item id="crpg_disabled_handgonne_v1_h2" name="{=Meow}Handgonne test +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
-    <ItemComponent>
-      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="113" accuracy="97" thrust_damage="55" thrust_speed="82" speed_rating="32" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
-        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
-      </Weapon>
-    </ItemComponent>
-    <Flags />
-  </Item>
-  <Item id="crpg_disabled_handgonne_v1_h3" name="{=Meow}Handgonne test +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
-    <ItemComponent>
-      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="114" accuracy="98" thrust_damage="56" thrust_speed="83" speed_rating="33" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
-        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
-      </Weapon>
-    </ItemComponent>
-    <Flags />
-  </Item>
   <Item id="crpg_disabled_wheellock_v1_h0" name="{=AppleTruce}Wheellock test" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
-      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="108" accuracy="97" thrust_damage="44" thrust_speed="84" speed_rating="34" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="97" accuracy="98" thrust_damage="34" thrust_speed="84" speed_rating="66" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="2" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
       </Weapon>
     </ItemComponent>
@@ -14462,7 +14430,7 @@
   </Item>
   <Item id="crpg_disabled_wheellock_v1_h1" name="{=AppleTruce}Wheellock test +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
-      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="108" accuracy="98" thrust_damage="45" thrust_speed="85" speed_rating="36" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="97" accuracy="99" thrust_damage="35" thrust_speed="85" speed_rating="68" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="2" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
       </Weapon>
     </ItemComponent>
@@ -14470,7 +14438,7 @@
   </Item>
   <Item id="crpg_disabled_wheellock_v1_h2" name="{=AppleTruce}Wheellock test +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
-      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="109" accuracy="99" thrust_damage="46" thrust_speed="86" speed_rating="38" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="98" accuracy="100" thrust_damage="36" thrust_speed="86" speed_rating="70" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="2" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
       </Weapon>
     </ItemComponent>
@@ -14478,7 +14446,7 @@
   </Item>
   <Item id="crpg_disabled_wheellock_v1_h3" name="{=AppleTruce}Wheellock test +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,-0.05,-0.05">
     <ItemComponent>
-      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="110" accuracy="100" thrust_damage="47" thrust_speed="87" speed_rating="39" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="99" accuracy="101" thrust_damage="37" thrust_speed="87" speed_rating="71" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="2" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
         <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
       </Weapon>
     </ItemComponent>

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -14420,6 +14420,70 @@
     </ItemComponent>
     <Flags />
   </Item>
+  <Item id="crpg_disabled_handgonne_v1_h0" name="{=Meow}Handgonne test" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="112" accuracy="95" thrust_damage="53" thrust_speed="80" speed_rating="28" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_disabled_handgonne_v1_h1" name="{=Meow}Handgonne test +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="112" accuracy="96" thrust_damage="54" thrust_speed="81" speed_rating="30" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_disabled_handgonne_v1_h2" name="{=Meow}Handgonne test +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="113" accuracy="97" thrust_damage="55" thrust_speed="82" speed_rating="32" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_disabled_handgonne_v1_h3" name="{=Meow}Handgonne test +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="handcannon" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="114" accuracy="98" thrust_damage="56" thrust_speed="83" speed_rating="33" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_disabled_wheellock_v1_h0" name="{=AppleTruce}Wheellock test" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="108" accuracy="97" thrust_damage="44" thrust_speed="84" speed_rating="34" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_disabled_wheellock_v1_h1" name="{=AppleTruce}Wheellock test +1" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="108" accuracy="98" thrust_damage="45" thrust_speed="85" speed_rating="36" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_disabled_wheellock_v1_h2" name="{=AppleTruce}Wheellock test +2" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="109" accuracy="99" thrust_damage="46" thrust_speed="86" speed_rating="38" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_disabled_wheellock_v1_h3" name="{=AppleTruce}Wheellock test +3" body_name="bo_composite_crossbows" culture="Culture.vlandia" mesh="wheellock" weight="7.0" appearance="0.7" difficulty="40" Type="Musket" AmmoOffset="0.0, 0.02131, 0.22975" item_holsters="cla_firearms:cla_firearms2" holster_position_shift="0.02,0,-0.4">
+    <ItemComponent>
+      <Weapon weapon_class="Musket" ammo_class="Cartridge" missile_speed="110" accuracy="100" thrust_damage="47" thrust_speed="87" speed_rating="39" weapon_length="100" ammo_limit="1" thrust_damage_type="Pierce" item_usage="crossbow_light" reload_phase_count="1" physics_material="wood_weapon" center_of_mass="0,0,0.4" modifier_group="crossbow">
+        <WeaponFlags RangedWeapon="true" HasString="false" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" FirearmAmmo="true" CantReloadOnHorseback="true" CanPenetrateShield="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
   <CraftedItem id="crpg_disabled_jamescross_v1_h0" name="{=Yeldur}St. James Cross" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_jamescross_1h_blade_h0" Type="Blade" scale_factor="100" />


### PR DESCRIPTION
This adds two disable versions of the guns as test objects. This adds two stage reload to guns by asigning them the light xbow reload item usage.  They already use light xbow animation and not stuck in place, intent of this is to split that into two stages.  Guns are balanced back to same tier as previously **only** by reducing reload speed.  We can test to see how much this changes effective reload speed. Also curious to see how this effects starting, whether it starts loaded or not.