### PR TITLE
Fix Meowdao weight distrib issue

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -31816,80 +31816,80 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h0" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.7">
+  <CraftingPiece id="crpg_meowdao_blade_h0" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h1" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.64">
+  <CraftingPiece id="crpg_meowdao_blade_h1" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h2" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.64">
+  <CraftingPiece id="crpg_meowdao_blade_h2" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h3" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.6">
+  <CraftingPiece id="crpg_meowdao_blade_h3" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_pommel_h0" name="{=}Meowdao Pommel" tier="4" piece_type="Pommel" mesh="meowdao_pommel" culture="Culture.battania" length="2.5" weight="0.12">
+  <CraftingPiece id="crpg_meowdao_pommel_h0" name="{=}Meowdao Pommel" tier="4" piece_type="Pommel" mesh="meowdao_pommel" culture="Culture.battania" length="2.5" weight="0.55">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_pommel_h1" name="{=}Meowdao Pommel" tier="4" piece_type="Pommel" mesh="meowdao_pommel" culture="Culture.battania" length="2.5" weight="0.12">
+  <CraftingPiece id="crpg_meowdao_pommel_h1" name="{=}Meowdao Pommel" tier="4" piece_type="Pommel" mesh="meowdao_pommel" culture="Culture.battania" length="2.5" weight="0.51">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_pommel_h2" name="{=}Meowdao Pommel" tier="4" piece_type="Pommel" mesh="meowdao_pommel" culture="Culture.battania" length="2.5" weight="0.12">
+  <CraftingPiece id="crpg_meowdao_pommel_h2" name="{=}Meowdao Pommel" tier="4" piece_type="Pommel" mesh="meowdao_pommel" culture="Culture.battania" length="2.5" weight="0.49">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_pommel_h3" name="{=}Meowdao Pommel" tier="4" piece_type="Pommel" mesh="meowdao_pommel" culture="Culture.battania" length="2.5" weight="0.12">
+  <CraftingPiece id="crpg_meowdao_pommel_h3" name="{=}Meowdao Pommel" tier="4" piece_type="Pommel" mesh="meowdao_pommel" culture="Culture.battania" length="2.5" weight="0.45">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_guard_h0" name="{=}Meowdao Guard" tier="5" piece_type="Guard" mesh="meowdao_guard" culture="Culture.battania" length="1.37" weight="0.097">
+  <CraftingPiece id="crpg_meowdao_guard_h0" name="{=}Meowdao Guard" tier="5" piece_type="Guard" mesh="meowdao_guard" culture="Culture.battania" length="1.37" weight="0.55">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="3" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_guard_h1" name="{=}Meowdao Guard" tier="5" piece_type="Guard" mesh="meowdao_guard" culture="Culture.battania" length="1.37" weight="0.097">
+  <CraftingPiece id="crpg_meowdao_guard_h1" name="{=}Meowdao Guard" tier="5" piece_type="Guard" mesh="meowdao_guard" culture="Culture.battania" length="1.37" weight="0.55">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="3" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_guard_h2" name="{=}Meowdao Guard" tier="5" piece_type="Guard" mesh="meowdao_guard" culture="Culture.battania" length="1.37" weight="0.097">
+  <CraftingPiece id="crpg_meowdao_guard_h2" name="{=}Meowdao Guard" tier="5" piece_type="Guard" mesh="meowdao_guard" culture="Culture.battania" length="1.37" weight="0.55">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="3" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_guard_h3" name="{=}Meowdao Guard" tier="5" piece_type="Guard" mesh="meowdao_guard" culture="Culture.battania" length="1.37" weight="0.097">
+  <CraftingPiece id="crpg_meowdao_guard_h3" name="{=}Meowdao Guard" tier="5" piece_type="Guard" mesh="meowdao_guard" culture="Culture.battania" length="1.37" weight="0.55">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="3" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_handle_h0" name="{=}Meowdao Handle" tier="3" piece_type="Handle" mesh="meowdao_handle" culture="Culture.khuzait" length="44.5" weight="0.1">
+  <CraftingPiece id="crpg_meowdao_handle_h0" name="{=}Meowdao Handle" tier="3" piece_type="Handle" mesh="meowdao_handle" culture="Culture.khuzait" length="44.5" weight="0.55">
     <BuildData piece_offset="-6.5" previous_piece_offset="0.1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_handle_h1" name="{=}Meowdao Handle" tier="3" piece_type="Handle" mesh="meowdao_handle" culture="Culture.khuzait" length="44.5" weight="0.1">
+  <CraftingPiece id="crpg_meowdao_handle_h1" name="{=}Meowdao Handle" tier="3" piece_type="Handle" mesh="meowdao_handle" culture="Culture.khuzait" length="44.5" weight="0.55">
     <BuildData piece_offset="-6.5" previous_piece_offset="0.1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_handle_h2" name="{=}Meowdao Handle" tier="3" piece_type="Handle" mesh="meowdao_handle" culture="Culture.khuzait" length="44.5" weight="0.1">
+  <CraftingPiece id="crpg_meowdao_handle_h2" name="{=}Meowdao Handle" tier="3" piece_type="Handle" mesh="meowdao_handle" culture="Culture.khuzait" length="44.5" weight="0.55">
     <BuildData piece_offset="-6.5" previous_piece_offset="0.1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_handle_h3" name="{=}Meowdao Handle" tier="3" piece_type="Handle" mesh="meowdao_handle" culture="Culture.khuzait" length="44.5" weight="0.1">
+  <CraftingPiece id="crpg_meowdao_handle_h3" name="{=}Meowdao Handle" tier="3" piece_type="Handle" mesh="meowdao_handle" culture="Culture.khuzait" length="44.5" weight="0.39">
     <BuildData piece_offset="-6.5" previous_piece_offset="0.1" next_piece_offset="0" />
   </CraftingPiece>
   <CraftingPiece id="crpg_fangtian_ji_pommel_h0" name="{=}Fangtian Ji Pommel" tier="4" piece_type="Pommel" mesh="qinglong_pommel" culture="Culture.empire" length="7.17" weight="0" full_scale="true">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -12636,7 +12636,7 @@
       <Piece id="crpg_shep_damast_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_meowdao_v1_h0" name="{=kaikaikai}Meowdao" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_meowdao_v2_h0" name="{=kaikaikai}Meowdao" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_meowdao_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_meowdao_guard_h0" Type="Guard" scale_factor="100" />
@@ -12644,7 +12644,7 @@
       <Piece id="crpg_meowdao_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_meowdao_v1_h1" name="{=kaikaikai}Meowdao +1" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_meowdao_v2_h1" name="{=kaikaikai}Meowdao +1" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_meowdao_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_meowdao_guard_h1" Type="Guard" scale_factor="100" />
@@ -12652,7 +12652,7 @@
       <Piece id="crpg_meowdao_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_meowdao_v1_h2" name="{=kaikaikai}Meowdao +2" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_meowdao_v2_h2" name="{=kaikaikai}Meowdao +2" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_meowdao_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_meowdao_guard_h2" Type="Guard" scale_factor="100" />
@@ -12660,7 +12660,7 @@
       <Piece id="crpg_meowdao_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_meowdao_v1_h3" name="{=kaikaikai}Meowdao +3" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_meowdao_v2_h3" name="{=kaikaikai}Meowdao +3" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_meowdao_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_meowdao_guard_h3" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
Meowdao presently suffers with an issue of bad weight distribution leading to exceptionally slow swings, this change serves to better redistribute weight between components.

Currently this does lower the tier of the weapon as it loses handling, at present I've chosen to ignore this as I think it may be better off filling a space in the slightly-lower tiers for a more budget-friendly 2h (which are sorely lacking in the 2h category rn) - This can however be adjusted if we feel it necessary.